### PR TITLE
Add filetype to window buffer.

### DIFF
--- a/lua/lazy/view/init.lua
+++ b/lua/lazy/view/init.lua
@@ -87,6 +87,7 @@ function M.show(mode)
   end
 
   vim.bo[buf].buftype = "nofile"
+  vim.bo[buf].filetype = "lazy"
   vim.bo[buf].bufhidden = "wipe"
   vim.wo[win].conceallevel = 3
   vim.wo[win].spell = false


### PR DESCRIPTION
Add a filetype to the Lazy window buffer, which allows plugins like codewindow to ignore it.