### PR TITLE
fix(checker): allow git checks only for non-pinned plugins

### DIFF
--- a/lua/lazy/manage/checker.lua
+++ b/lua/lazy/manage/checker.lua
@@ -16,7 +16,7 @@ end
 
 function M.fast_check()
   for _, plugin in pairs(Config.plugins) do
-    if plugin._.installed then
+    if not plugin.pin and plugin._.installed then
       plugin._.has_updates = nil
       local info = Git.info(plugin.dir)
       local ok, target = pcall(Git.get_target, plugin)

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -8,6 +8,9 @@ local M = {}
 M.log = {
   ---@param opts {updated?:boolean, check?: boolean}
   skip = function(plugin, opts)
+    if opts.check and plugin.pin then
+      return true
+    end
     if opts.updated and not (plugin._.updated and plugin._.updated.from ~= plugin._.updated.to) then
       return true
     end


### PR DESCRIPTION
According to the docs when a plugin spec has the `pin` value as true then it doesn't participate in updates.
Thus, this patch ensures that no git checks are done for that plugin in case the `pin` option is set to true.
(no notifications or indications in the Lazy window about updates)