### PR TITLE
fix: only use dev url if plugin exists

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -93,7 +93,7 @@ function Spec:add(plugin, is_dep)
       end
     end
     -- dev plugins
-    if plugin.dev then
+    if plugin.dev and vim.loop.fs_stat(Config.options.dev.path .. "/" .. plugin.name) then
       plugin.dir = Config.options.dev.path .. "/" .. plugin.name
     else
       -- remote plugin


### PR DESCRIPTION
## Motivation

I have one setup for my work computer, and one personal. I only work on my own plugins on my personal laptop.
I really enjoy the dev option to easily use my local install of the plugin. However, I would like it to automatically fallback to remote if local installation is not found.

Let me know if you have any issues with this change!