### PR TITLE
fix(clean): update lockfile on clean

### DIFF
--- a/lua/lazy/manage/init.lua
+++ b/lua/lazy/manage/init.lua
@@ -153,7 +153,9 @@ function M.clean(opts)
   return M.run({
     pipeline = { "fs.clean" },
     plugins = Config.to_clean,
-  }, opts)
+  }, opts):wait(function()
+    require("lazy.manage.lock").update()
+  end)
 end
 
 function M.clear()


### PR DESCRIPTION
This PR updates the lockfile when executing the `clean` command.

Relates: #82 