### PR TITLE
fix(mapping): fix buffer being properly deleted

### DIFF
--- a/lua/lazy/view/init.lua
+++ b/lua/lazy/view/init.lua
@@ -102,11 +102,11 @@ function M.show(mode)
     M._buf = nil
     vim.diagnostic.reset(Config.ns, buf)
     vim.schedule(function()
-      if vim.api.nvim_buf_is_valid(buf) then
-        vim.api.nvim_buf_delete(buf, { force = true })
-      end
       if vim.api.nvim_win_is_valid(win) then
         vim.api.nvim_win_close(win, true)
+      end
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
       end
     end)
   end


### PR DESCRIPTION
Fix #81 

This fixes my issue. Check the comment on the issue for my finding on `vim.api.nvim_win_close()`

https://github.com/folke/lazy.nvim/issues/81#issuecomment-1363221392