### PR TITLE
Changed Header For Plugins Not Loaded to "Not Loaded"

### DIFF
--- a/lua/lazy/view/sections.lua
+++ b/lua/lazy/view/sections.lua
@@ -90,6 +90,6 @@ return {
     filter = function(plugin)
       return plugin._.installed
     end,
-    title = "Installed",
+    title = "Not Loaded",
   },
 }


### PR DESCRIPTION
Made it more clear that plugins listed as "Installed" are actually just lazy-loaded plugins that are not loaded.