### PR TITLE
More `Packer` migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ When `[2]` is `nil`, then the real mapping has to be created by the `config()` f
       require("neo-tree").setup()
       end,
 }
+
+-- Example for vim-surround
+{
+    "tpope/surround", keys = { { 'S', mode = 'v' }, 'y', 'd', 'c' }
+}
 ```
 
 ### Versioning

--- a/README.md
+++ b/README.md
@@ -582,6 +582,8 @@ For a real-life example, you can check my personal dots:
 - `lock` ➡️ `pin`
 - `disable=true` ➡️ `enabled = false`
 - `tag='*'` ➡️ `version="*"`
+- `wants` ⚠️ **Not supported**
+- `after` ⚠️ **Not supported**
 - `module` is auto-loaded. No need to specify
 - `keys` spec is [different](#%EF%B8%8F-lazy-key-mappings)
 


### PR DESCRIPTION
Seeing how many people struggled to convert their packer plugin spec to lazy, myself included. Especially it wasn't clear how different it's to set mode in packer vs lazy. 

Hopefully this extra example can help a couple of poor soul out there in their exodus.