### PR TITLE
docs: fix plugin setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,18 +202,18 @@ return {
     end,
   },
 
-  -- the above could also be written as
+  -- the above could also be written as:
   {
     "nvim-neorg/neorg",
     ft = "norg",
-    config = true, -- run require("norg").setup()
+    config = true, -- run require("neorg").setup()
   },
 
   -- or set custom config
   {
     "nvim-neorg/neorg",
     ft = "norg",
-    config = { foo = "bar" }, -- run require("norg").setup({foo = "bar"})
+    config = { foo = "bar" }, -- run require("neorg").setup({foo = "bar"})
   },
 
   {


### PR DESCRIPTION
I'd like to also add a note that makes it clear the plugin's require doesn't have to be the same as the plugin's URL.
I.E:
`folke/trouble.nvim` -> `require('trouble').setup()` and not `require('trouble.nvim').setup()`
`kazhala/close-buffers.nvim` -> `require('close_buffers').setup()` and not `require('close-buffers.nvim').setup()`
I had to try and see if it works even if the name of the plugin differs from the `require()` of it.
Thanks.