### PR TITLE
fix(reloader): remove extra trailing separator

### DIFF
--- a/lua/lazy/manage/reloader.lua
+++ b/lua/lazy/manage/reloader.lua
@@ -19,7 +19,7 @@ function M.enable()
   end
   if type(Config.spec) == "string" then
     M.timer = vim.loop.new_timer()
-    M.root = vim.fn.stdpath("config") .. "/lua/"
+    M.root = vim.fn.stdpath("config") .. "/lua"
     M.check(true)
     M.timer:start(2000, 2000, M.check)
   end


### PR DESCRIPTION
There is an extra redundant trailing separator in the `root` path in the reloader which also breaks the `fnamemodify` for correctly representing the path to the changed file in the notifcation.

This is how it looks before the change:
![Screenshot from 2022-12-26 20-25-29](https://user-images.githubusercontent.com/20475201/209575819-e648bd12-acc5-4c19-9f2c-395f0c7b131b.png)
