### PR TITLE
Update link to point to directory instead of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ For a real-life example, you can check my personal dots:
 
 - [init.lua](https://github.com/folke/dot/blob/master/config/nvim/init.lua) where I require `config.lazy`
 - [config.lazy](https://github.com/folke/dot/blob/master/config/nvim/lua/config/lazy.lua) where I bootstrap and setup **lazy.nvim**
-- [config.plugins](https://github.com/folke/dot/blob/master/config/nvim/lua/config/plugins.lua) is my main plugin config module
+- [config.plugins](https://github.com/folke/dot/blob/master/config/nvim/lua/config/plugins/) is my main plugin config module
 - Any submodule of [config.plugins (submodules)](https://github.com/folke/dot/tree/master/config/nvim/lua/config/plugins) will be automatically loaded as well.
 
 ## 📦 Migration Guide


### PR DESCRIPTION
I presume this file got split up at some point, so the module is now in a directory.