### PR TITLE
fix(types): extended keys type for LazySpec

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -29,7 +29,7 @@ local M = {}
 ---@field event? string[]
 ---@field cmd? string[]
 ---@field ft? string[]
----@field keys? string[]
+---@field keys? string[]|{mode:string|string[],[number]:string}[]
 ---@field module? false
 
 ---@class LazyPluginRef


### PR DESCRIPTION
type adapted for these variants
```lua
keys = { { 'a', 'b', 'c', mode = 'x' } }
keys = { { 'a', 'b', 'c', mode = { 'x', 'o' } } },
```