### PR TITLE
Fix E5108 in getcompletions

### DIFF
--- a/lua/lazy/view/commands.lua
+++ b/lua/lazy/view/commands.lua
@@ -56,7 +56,7 @@ M.commands = {
 }
 
 function M.complete(cmd, prefix)
-  if not ViewConfig.commands[cmd].plugins then
+  if not (ViewConfig.commands[cmd] or {}).plugins then
     return
   end
   ---@type string[]


### PR DESCRIPTION
`:echo getcompletion('Laz ', 'cmdline')` results in the following error (notice the extra space in 'Laz ')

```
E5108: Error executing Lua function: ...cal/share/nvim/lazy/lazy.nvim/lua/lazy/view/commands.lua:60: attempt to index a nil value                                             
stack traceback:                                                                                                                                                              
        ...cal/share/nvim/lazy/lazy.nvim/lua/lazy/view/commands.lua:60: in function <...cal/share/nvim/lazy/lazy.nvim/lua/lazy/view/commands.lua:58>             
```
