### PR TITLE
chore(ui): nicer threshold prompt

### DIFF
--- a/lua/lazy/view/init.lua
+++ b/lua/lazy/view/init.lua
@@ -85,7 +85,7 @@ function M.create()
   self:on_key(ViewConfig.keys.profile_filter, function()
     if self.state.mode == "profile" then
       vim.ui.input({
-        prompt = "Enter time threshold in ms, like 0.5",
+        prompt = "Enter time threshold in ms: ",
         default = tostring(self.state.profile.threshold),
       }, function(input)
         if not input then


### PR DESCRIPTION
Hi Folke,

Great plugin! Here's a little change to the prompt:

From

![Screenshot 2022-12-28 at 14 18 43](https://user-images.githubusercontent.com/1009936/209818374-9f407098-8666-4f0c-963c-2b6c93f6c5cf.png)

to

![Screenshot 2022-12-28 at 14 17 05](https://user-images.githubusercontent.com/1009936/209818168-8138700f-8057-4886-b357-83d9c339bc24.png)

Note: The default value is already set in the beginning. The original prompt didn't make it clear, that `0` is the default and `0.5` is an example.