### PR TITLE
fix(help): properly escape helptags search pattern

### DIFF
--- a/lua/lazy/help.lua
+++ b/lua/lazy/help.lua
@@ -18,6 +18,7 @@ function M.index(plugin)
         if title then
           local tag = plugin.name .. "-" .. title:lower():gsub("%W+", "-")
           tag = tag:gsub("%-+", "-"):gsub("%-$", "")
+          line = line:gsub("([%[%]/])", "\\%1")
           tags[tag] = { tag = tag, line = line, file = plugin.name .. ".md" }
         end
       end


### PR DESCRIPTION
Example:

```
nui.nvim-popup-lua-nui-popup	nui.nvim.md	/### \[Popup\](lua\/nui\/popup)
```