### PR TITLE
fix references to config.plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,8 +661,8 @@ For a real-life example, you can check my personal dots:
 
 - [init.lua](https://github.com/folke/dot/blob/master/config/nvim/init.lua) where I require `config.lazy`
 - [config.lazy](https://github.com/folke/dot/blob/master/config/nvim/lua/config/lazy.lua) where I bootstrap and setup **lazy.nvim**
-- [config.plugins](https://github.com/folke/dot/blob/master/config/nvim/lua/config/plugins/init.lua) is my main plugin config module
-- Any submodule of [config.plugins (submodules)](https://github.com/folke/dot/tree/master/config/nvim/lua/config/plugins) will be automatically loaded as well.
+- [config.plugins](https://github.com/folke/dot/blob/master/config/nvim/lua/plugins/init.lua) is my main plugin config module
+- Any submodule of [config.plugins (submodules)](https://github.com/folke/dot/tree/master/config/nvim/lua/plugins) will be automatically loaded as well.
 
 ## 📦 Migration Guide
 


### PR DESCRIPTION
It looks like the references to your personal configurations has changed directory structure from `lua/config/plugins` to `lua/plugins`.