### PR TITLE
docs: fix references to config.plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ For a real-life example, you can check my personal dots:
 
 - [init.lua](https://github.com/folke/dot/blob/master/config/nvim/init.lua) where I require `config.lazy`
 - [config.lazy](https://github.com/folke/dot/blob/master/config/nvim/lua/config/lazy.lua) where I bootstrap and setup **lazy.nvim**
-- [config.plugins](https://github.com/folke/dot/blob/master/config/nvim/lua/plugins/init.lua) is my main plugin config module
+- [config.plugins](https://github.com/folke/dot/tree/master/config/nvim/lua/plugins) is my main plugin config module
 - Any submodule of [config.plugins (submodules)](https://github.com/folke/dot/tree/master/config/nvim/lua/plugins) will be automatically loaded as well.
 
 ## 📦 Migration Guide


### PR DESCRIPTION
Hi, folke: I was following your new updates, and then I noticed that this link is broken. In the URL: both `tree` and `blob` can work, I picked the one used in the next line!

(Thank you for creating this great plugin and sharing your dotfiles btw! It helps me a lot during my config debugging!)