### PR TITLE
fix(keys): Use vim's default value for an unset g:mapleader

### DIFF
--- a/lua/lazy/core/handler/keys.lua
+++ b/lua/lazy/core/handler/keys.lua
@@ -15,7 +15,7 @@ local M = {}
 
 ---@param feed string
 function M.replace_special(feed)
-  for special, key in pairs({ leader = vim.g.mapleader, localleader = vim.g.maplocalleader }) do
+  for special, key in pairs({ leader = vim.g.mapleader or "\\", localleader = vim.g.maplocalleader or "\\" }) do
     local pattern = "<"
     for i = 1, #special do
       pattern = pattern .. "[" .. special:sub(i, i) .. special:upper():sub(i, i) .. "]"


### PR DESCRIPTION
As the docs clearly state Lazy requires a user to set their `mapleader` before starting Lazy in order for the keys to work correctly.

But Lazy doesn't take into consideration the default behavior of VIM which is:
> If "g:mapleader" is not set or empty, a backslash is used instead.

That means that users that were previously dependent on the default behavior of VIM, now will have to explicitly change their `mapleader` to `vim.g.mapleader = "\\"`, which can be inconvenient or raise some issues. 

This stopped working after https://github.com/folke/lazy.nvim/commit/507b695753b4a7e1eff75f578b7a04b6307e4bc6 was introduced.

What do you think? @folke 