### PR TITLE
feat: Move Update section above Updated

### DIFF
--- a/lua/lazy/view/sections.lua
+++ b/lua/lazy/view/sections.lua
@@ -49,6 +49,13 @@ return {
   {
     ---@param plugin LazyPlugin
     filter = function(plugin)
+      return plugin._.updates
+    end,
+    title = "Updates",
+  },
+  {
+    ---@param plugin LazyPlugin
+    filter = function(plugin)
       return plugin._.updated and plugin._.updated.from ~= plugin._.updated.to
     end,
     title = "Updated",
@@ -59,13 +66,6 @@ return {
       return plugin._.cloned
     end,
     title = "Installed",
-  },
-  {
-    ---@param plugin LazyPlugin
-    filter = function(plugin)
-      return plugin._.updates
-    end,
-    title = "Updates",
   },
   {
     filter = function(plugin)


### PR DESCRIPTION
Before, the list of plugins that were just updated would appear above the list of plugins that are still to be updated. So if you are trying to update each plugin one at a time, you would have to keep going down farther and farther to get back to the list of pending updates.

By switching the order of the two sections, the list of pending updates stays first and makes it easier to read the changes of each plugin before updating them.

The git diff here makes it look (to me at least) stranger than it is. All that happened was the one section moved:

### original
```lua
  {
    ---@param plugin LazyPlugin
    filter = function(plugin)
      return plugin._.updated and plugin._.updated.from ~= plugin._.updated.to
    end,
    title = "Updated",
  },
  {
    ---@param plugin LazyPlugin
    filter = function(plugin)
      return plugin._.cloned
    end,
    title = "Installed",
  },
  {
    ---@param plugin LazyPlugin
    filter = function(plugin)
      return plugin._.updates
    end,
    title = "Updates",
  },
```

### PR
```lua
  {
    ---@param plugin LazyPlugin
    filter = function(plugin)
      return plugin._.updates
    end,
    title = "Updates",
  },
  {
    ---@param plugin LazyPlugin
    filter = function(plugin)
      return plugin._.updated and plugin._.updated.from ~= plugin._.updated.to
    end,
    title = "Updated",
  },
  {
    ---@param plugin LazyPlugin
    filter = function(plugin)
      return plugin._.cloned
    end,
    title = "Installed",
  },

```
