### PR TITLE
Don't cache check for attached UIs

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -159,7 +159,9 @@ M.me = nil
 ---@type string
 M.mapleader = nil
 
-M.headless = #vim.api.nvim_list_uis() == 0
+function M.headless()
+    return #vim.api.nvim_list_uis() == 0
+end
 
 ---@param opts? LazyConfig
 function M.setup(opts)
@@ -200,7 +202,7 @@ function M.setup(opts)
   vim.go.loadplugins = false
   M.mapleader = vim.g.mapleader
 
-  if M.headless then
+  if M.headless() then
     require("lazy.view.commands").setup()
   else
     vim.api.nvim_create_autocmd("UIEnter", {

--- a/lua/lazy/view/init.lua
+++ b/lua/lazy/view/init.lua
@@ -31,7 +31,7 @@ end
 
 ---@param mode? string
 function M.show(mode)
-  if Config.headless then
+  if Config.headless() then
     return
   end
 


### PR DESCRIPTION
UIs can attach and detach from headless nvim dynamically (indeed, this is one of its use cases).