### PR TITLE
Allow commands like `Lazy ... | ...`

### DIFF
--- a/lua/lazy/view/commands.lua
+++ b/lua/lazy/view/commands.lua
@@ -94,6 +94,7 @@ function M.setup()
     end
     M.cmd(prefix, opts)
   end, {
+    bar = true,
     bang = true,
     nargs = "?",
     desc = "Lazy",


### PR DESCRIPTION
Set bar attribute:
```
-bar	    The command can be followed by a "|" and another command.
```