### PR TITLE
feat: add buffer name

### DIFF
--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -94,6 +94,7 @@ function M:mount()
   else
     self.buf = vim.api.nvim_create_buf(false, false)
   end
+  vim.api.nvim_buf_set_name(self.buf, "LazyFloat")
 
   self:layout()
   self.win = vim.api.nvim_open_win(self.buf, true, self.win_opts)


### PR DESCRIPTION


This is a simple change to make the floating window buffer used by lazy have a specific name.

The reason for this change is that I use a voice coding system that relies on reading out window titles to establish a specific context to enable and disable certain command grammars, and for plugin specific windows the easiest way to differentiate is to use the buffer name which can be placed into the vim title.
