### PR TITLE
Allow merging lists in lazy.core.util.merge

### DIFF
--- a/lua/lazy/core/util.lua
+++ b/lua/lazy/core/util.lua
@@ -302,6 +302,10 @@ local function can_merge(v)
   return type(v) == "table" and (vim.tbl_isempty(v) or not M.is_list(v))
 end
 
+local function can_merge_list(v)
+  return type(v) == "table" and M.is_list(v)
+end
+
 --- Merges the values similar to vim.tbl_deep_extend with the **force** behavior,
 --- but the values can be any type, in which case they override the values on the left.
 --- Values will me merged in-place in the first left-most table. If you want the result to be in
@@ -323,6 +327,12 @@ function M.merge(...)
     if can_merge(ret) and can_merge(value) then
       for k, v in pairs(value) do
         ret[k] = M.merge(ret[k], v)
+      end
+    elseif can_merge_list(ret) and can_merge_list(value) then
+      for _, v in ipairs(value) do
+        if not vim.tbl_contains(ret, v) then
+        ret[#ret+1] = v
+        end
       end
     elseif value == vim.NIL then
       ret = nil

--- a/tests/core/util_spec.lua
+++ b/tests/core/util_spec.lua
@@ -145,7 +145,11 @@ describe("util", function()
       },
       {
         input = { { a = { 1, 2 } }, { a = { 3 } } },
-        output = { a = { 3 } },
+        output = { a = { 1, 2, 3 } },
+      },
+      {
+        input = { { a = { 1, 2 } }, { a = { 1, 3 } } },
+        output = { a = { 1, 2, 3 } },
       },
       {
         input = { { b = { 1, 2 } }, { a = { 3 }, b = vim.NIL } },


### PR DESCRIPTION
Not sure if this is worth including, I thought I'd just give it a shot.

This PR changes the merge function to allow merging lists of simple types. If a value already exists an a list, it is not added again, so the list basically acts like an ordered set. I figured this might be more useful than the default behavior of simply overwriting.

My use-case is the following: My dotfiles are fairly modular, and I'm loading the [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) plugin from multiple locations (once for Rust, once for Lua, etc.) with different values of the [`ensure_installed`](https://github.com/nvim-treesitter/nvim-treesitter#modules) key to add a number of parsers (for Rust and TOML, for Lua, etc.). With lazy.nvim's current behavior, I have to merge these lists manually, which is a bit of a chore.

I've encountered lists within config tables in some other plugins as well: [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) (the `sources` key, although that's a list of tables), [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) (several), [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) (the `sources` key).

Again, if this is too niche, no problem.