### PR TITLE
fix(render): get profile_{sort,filter} key bindings from ViewConfig

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -583,12 +583,12 @@ function M:profile()
   self:append("Profile", "LazyH2"):nl():nl()
   self
     :append("You can press ")
-    :append("<C-s>", "LazySpecial")
+    :append(ViewConfig.keys.profile_sort, "LazySpecial")
     :append(" to change sorting between chronological order & time taken.")
     :nl()
   self
     :append("Press ")
-    :append("<C-f>", "LazySpecial")
+    :append(ViewConfig.keys.profile_filter, "LazySpecial")
     :append(" to filter profiling entries that took more time than a given threshold")
     :nl()
 


### PR DESCRIPTION
Thanks for this nice plugin manager. I wanted to re-enable `<C-f>` for 'page forward' (https://github.com/folke/lazy.nvim/issues/133#issuecomment-1364299821) and noticed that the help text under `Profile (P)` wasn't updated to reflect the change. This pull request should hopefully fix that.