### PR TITLE
feat(option): fallback to git when local plugin doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ return {
     path = "~/projects",
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
+    fallback = false, -- Fallback to git when local plugin doesn't exist
   },
   install = {
     -- install missing plugins on startup. This doesn't increase startup time.

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -31,6 +31,7 @@ M.defaults = {
     path = "~/projects",
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
+    fallback = false, -- Fallback to git when local plugin doesn't exist
   },
   install = {
     -- install missing plugins on startup. This doesn't increase startup time.

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -91,7 +91,7 @@ function Spec:add(plugin, results, is_dep)
       end
     end
     -- dev plugins
-    if plugin.dev then
+    if plugin.dev and vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1 then
       plugin.dir = Config.options.dev.path .. "/" .. plugin.name
     else
       -- remote plugin

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -91,7 +91,10 @@ function Spec:add(plugin, results, is_dep)
       end
     end
     -- dev plugins
-    if plugin.dev and vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1 then
+    if
+      plugin.dev
+      and (not Config.options.dev.fallback or vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1)
+    then
       plugin.dir = Config.options.dev.path .. "/" .. plugin.name
     else
       -- remote plugin


### PR DESCRIPTION
Related: https://www.reddit.com/r/neovim/comments/zk187u/how_does_everyone_segment_plugin_development_from/

I used to have a custom use function in packer (Which is no longer possible in lazy.nvim):

```lua
local use = function(opts)
  if opts.dev and vim.fn.isdirectory(vim.fn.expand(opts.dev)) ~= 0 then opts[1] = opts.dev end
  require("packer").use(opts)
end
use { "catppuccin/nvim", dev = "~/code/git/catppuccin" }
```

With lazy.nvim there's an useful option known as `dev` and it even supports `patterns`! However, I can no longer (easily) sync my config between machines as local plugin dir wouldn't be found

This PR adds an option called `dev.fallback` to fallback to git plugin when local plugin dir doesn't exist
