### PR TITLE
Use "wslview" instead of "xdg-open" in WSL

### DIFF
--- a/lua/lazy/util.lua
+++ b/lua/lazy/util.lua
@@ -25,6 +25,8 @@ function M.open(uri)
   else
     if vim.fn.executable("xdg-open") then
       cmd = { "xdg-open", uri }
+    elseif vim.fn.executable("wslview") then
+      cmd = { "wslview", uri }
     else
       cmd = { "open", uri }
     end


### PR DESCRIPTION
In WSL there is wslview instead of xdg-open.
We can change it by setting it in `ui.browser`, but I think it can be the default choice for WSL.