### PR TITLE
Fix(Error when triger on range defined command in `cmd`)

### DIFF
--- a/lua/lazy/core/handler/cmd.lua
+++ b/lua/lazy/core/handler/cmd.lua
@@ -19,7 +19,7 @@ function M:_add(cmd)
       bang = event.bang or nil,
       mods = event.smods,
       args = event.fargs,
-      count = event.count >= 0 and event.count or nil,
+      count = event.count >= 0 and event.range == 0 and event.count or nil,
     }
 
     if event.range == 1 then


### PR DESCRIPTION
# Bug with range commands in `cmd`

Hello, this is just a solution proposal, I hope I don't offend anyone, let alone your fantastic work.

try to fix the bug with the commands defined by `cmd` when executed with a range, as it doesn't accept the count property.

An example of the error is try to lazy load a [Tabular plugin](https://github.com/godlygeek/tabular) 

```lua

{
  "godlygeek/tabular",
   cmd = {"Tabularize" } 
},
```

Executing the command with a range, for example: `:'<,'>Tabularize /=`, this causes an exception, because the count property is not compatible with range commands:

```
Error executing Lua callback: .../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:34: Command cannot accept a count
stack traceback:
        [C]: in function 'cmd'
        .../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:34: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>
```
I tried to solve it by adding the evaluation of the range to the counter condition
