### PR TITLE
feat: disable folding of floating window

### DIFF
--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -107,6 +107,7 @@ function M:mount()
   local function opts()
     vim.bo[self.buf].bufhidden = "wipe"
     vim.wo[self.win].conceallevel = 3
+    vim.wo[self.win].foldenable = false
     vim.wo[self.win].spell = false
     vim.wo[self.win].wrap = true
     vim.wo[self.win].winhighlight = "Normal:LazyNormal"


### PR DESCRIPTION
When `'foldenable'` is `true` the contents of floating window will be folded, which is not convenient.
<img width="1616" alt="image" src="https://user-images.githubusercontent.com/7381804/219334314-de97d958-792c-4adb-bd5b-8f920e7b9c1f.png">
