### PR TITLE
feat(render): dim housekeeping commits by default

### DIFF
--- a/lua/lazy/view/colors.lua
+++ b/lua/lazy/view/colors.lua
@@ -9,6 +9,7 @@ M.colors = {
   CommitIssue = "Number",
   CommitType = "Title", -- conventional commit type
   CommitScope = "Italic", -- conventional commit scope
+  Dimmed = "Conceal", -- property
   Prop = "Conceal", -- property
   Value = "@string", -- value of a property
   NoCond = "DiagnosticWarn", -- unloaded icon for a plugin where `cond()` was false

--- a/lua/lazy/view/config.lua
+++ b/lua/lazy/view/config.lua
@@ -24,6 +24,8 @@ function M.get_commands()
   return ret
 end
 
+M.dimmed_commits = { "build", "ci", "chore", "doc" }
+
 M.keys = {
   hover = "K",
   diff = "d",

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -456,21 +456,21 @@ function M:log(task)
         self:diagnostic({ message = "Breaking Changes", severity = vim.diagnostic.severity.WARN })
       end
       self:append(ref:sub(1, 7) .. " ", "LazyCommit", { indent = 6 })
-      if msg:match([[^chore]]) or msg:match([[^ci]]) or msg:match([[^doc]]) then
-        self:append(vim.trim(msg)):highlight({
-          ["."] = "LazyComment",
-        })
-      else
-        self:append(vim.trim(msg)):highlight({
-          ["#%d+"] = "LazyCommitIssue",
-          ["^%S+:"] = "LazyCommitType",
-          ["^%S+(%(.*%)):"] = "LazyCommitScope",
-          ["`.-`"] = "@text.literal.markdown_inline",
-          ["%*.-%*"] = "Italic",
-          ["%*%*.-%*%*"] = "Bold",
-        })
+
+      local dimmed = false
+      for _, dim in ipairs(ViewConfig.dimmed_commits) do
+        if msg:find("^" .. dim) then
+          dimmed = true
+        end
       end
-      -- string.gsub
+      self:append(vim.trim(msg), dimmed and "LazyDimmed" or nil):highlight({
+        ["#%d+"] = "LazyCommitIssue",
+        ["^%S+:"] = dimmed and "Bold" or "LazyCommitType",
+        ["^%S+(%(.*%)):"] = "LazyCommitScope",
+        ["`.-`"] = "@text.literal.markdown_inline",
+        ["%*.-%*"] = "Italic",
+        ["%*%*.-%*%*"] = "Bold",
+      })
       self:append(" " .. time, "LazyComment")
       self:nl()
     end

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -456,14 +456,20 @@ function M:log(task)
         self:diagnostic({ message = "Breaking Changes", severity = vim.diagnostic.severity.WARN })
       end
       self:append(ref:sub(1, 7) .. " ", "LazyCommit", { indent = 6 })
-      self:append(vim.trim(msg)):highlight({
-        ["#%d+"] = "LazyCommitIssue",
-        ["^%S+:"] = "LazyCommitType",
-        ["^%S+(%(.*%)):"] = "LazyCommitScope",
-        ["`.-`"] = "@text.literal.markdown_inline",
-        ["%*.-%*"] = "Italic",
-        ["%*%*.-%*%*"] = "Bold",
-      })
+      if msg:match([[^chore]]) or msg:match([[^ci]]) or msg:match([[^doc]]) then
+        self:append(vim.trim(msg)):highlight({
+          ["."] = "LazyComment",
+        })
+      else
+        self:append(vim.trim(msg)):highlight({
+          ["#%d+"] = "LazyCommitIssue",
+          ["^%S+:"] = "LazyCommitType",
+          ["^%S+(%(.*%)):"] = "LazyCommitScope",
+          ["`.-`"] = "@text.literal.markdown_inline",
+          ["%*.-%*"] = "Italic",
+          ["%*%*.-%*%*"] = "Bold",
+        })
+      end
       -- string.gsub
       self:append(" " .. time, "LazyComment")
       self:nl()


### PR DESCRIPTION
use `LazyComment` highlight group for commits with housekeeping types, i.e. chore/ci/doc

Inspired by [refined-github](https://github.com/refined-github/refined-github/blob/main/source/features/dim-bots.tsx)

### Log view

![image](https://user-images.githubusercontent.com/59826753/222433422-a0081aef-31ea-4a6a-a7e9-f7b223d540e7.png)
