### PR TITLE
fix(git): always set origin name when cloning

### DIFF
--- a/lua/lazy/manage/git.lua
+++ b/lua/lazy/manage/git.lua
@@ -196,9 +196,7 @@ end
 
 ---@param repo string
 function M.get_origin(repo)
-  local config = M.get_config(repo)
-  local remote = config["clone.defaultRemoteName"] or "origin"
-  return config["remote." .. remote .. ".url"] or config["remote.origin.url"]
+  return M.get_config(repo)["remote.origin.url"]
 end
 
 ---@param repo string

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -75,6 +75,8 @@ M.clone = {
       args[#args + 1] = "--recurse-submodules"
     end
 
+    args[#args + 1] = "--origin=origin"
+
     args[#args + 1] = "--progress"
 
     if self.plugin.branch then


### PR DESCRIPTION
related to https://github.com/folke/lazy.nvim/issues/602, "bug: not all git remotes are called 'origin'"

If honouring global git configs is considered out of scope, lazy can forcibly set the remote name instead 