### PR TITLE
fix(cache): fallback path in lsmod

### DIFF
--- a/lua/lazy/core/cache.lua
+++ b/lua/lazy/core/cache.lua
@@ -341,7 +341,7 @@ function M.lsmod(path)
         break
       end
       -- HACK: type is not always returned due to a bug in luv
-      t = t or uv.fs_stat(path .. "/" .. name).type
+      t = t or uv.fs_stat(path .. "/lua/" .. name).type
       ---@type string
       local topname
       local ext = name:sub(-4)


### PR DESCRIPTION
On my machine, the current stable branch yields

```
Error detected while processing ~/.config/nvim/init.lua:
E5113: Error while calling lua chunk: ....local/share/nvim/lazy/lazy.nvim/lua/lazy/core/cache.lua:344: attempt
to index a nil value
stack traceback:
        ....local/share/nvim/lazy/lazy.nvim/lua/lazy/core/cache.lua:344: in function 'lsmod'
        ....local/share/nvim/lazy/lazy.nvim/lua/lazy/core/cache.lua:251: in function '_find'
        ....local/share/nvim/lazy/lazy.nvim/lua/lazy/core/cache.lua:272: in function 'find'
        ....local/share/nvim/lazy/lazy.nvim/lua/lazy/core/cache.lua:131: in function <....local/share/nvim/lazy
/lazy.nvim/lua/lazy/core/cache.lua:129>
        [C]: in function 'require'
        ~/.local/share/nvim/lazy/lazy.nvim/lua/lazy/init.lua:47: in function 'setup'
        ~/.config/nvim/init.lua:29: in main chunk
```

for the followint init.lua:
```
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  vim.fn.system({
    "git",
    "clone",
    "--filter=blob:none",
    "https://github.com/folke/lazy.nvim.git",
    "--branch=stable", -- latest stable release
    lazypath,
  })
end
vim.opt.rtp:prepend(lazypath)

require("lazy").setup(  {
    "rcarriga/nvim-notify",
  }
)

```
.

Fixing the path makes lazy.nvim work as expected.

Versions before 9.8.0, respectively https://github.com/folke/lazy.nvim/tree/462633bae11255133f099163dda17180b3a6dc27 work as expected.