### PR TITLE
fix(readme): add example of multiple imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,18 @@ require("lazy").setup("plugins")
 require("lazy").setup({{import = "plugins"}})
 ```
 
+To import multiple modules from a plugin, add additional specs for each import.
+For example, to import LazyVim core plugins and an optional plugin:
+
+```lua
+require("lazy").setup({
+  spec = {
+    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
+    { import = "lazyvim.plugins.extras.coding.copilot" },
+  }
+)
+```
+
 When you import specs, you can override them by simply adding a spec for the same plugin to your local
 specs, adding any keys you want to override / merge.
 


### PR DESCRIPTION
I was originally repeating the plugin name on each spec:

```lua
require("lazy").setup({
  spec = {
    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
    { "LazyVim/LazyVim", import = "lazyvim.plugins.extras.ui.mini-starter" },
    { "LazyVim/LazyVim", import = "lazyvim.plugins.extras.coding.copilot" },
  },
})
```

Which resulted in the following `checkhealth` warning (at least once I added the second extra plugin:

```
lazy.nvim
 - WARNING {LazyVim}: overriding <import>
```

It didn't really occur to me that once the plugin was added, there was no need to specify it again.  You only need to specify the lua module to be imported.  So I figured an example of that would be helpful.