### PR TITLE
fix(home): show completely `reason` for `Not Loaded`

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -401,9 +401,11 @@ function M:plugin(plugin)
     local reason = {}
     for handler in pairs(Handler.types) do
       if plugin[handler] then
+        local trigger = {}
         for _, value in ipairs(plugin[handler]) do
-          reason[handler] = value
+          table.insert(trigger, type(value) == 'table' and value[1] or value)
         end
+        reason[handler] = table.concat(trigger, ' ')
       end
     end
     for _, other in pairs(Config.plugins) do


### PR DESCRIPTION
Hello,

Thanks for your amazing work on `Lazy.nvim`.
This PR adds showing the completely `reason` for `Not Loaded`


Config
```lua
  { 'numToStr/Comment.nvim', lazy = true, keys = { { '<leader>cc' }, { '<leader>cb' }, } },
  { 'fedepujol/move.nvim', lazy = true, cmd = { 'MoveLine', 'MoveBlock', 'MoveHChar', 'MoveHBlock' }, },
```
Before
![image](https://user-images.githubusercontent.com/90168447/226803199-a7fc6c9c-37d8-46d0-980a-e6c5b232b3e8.png)

After Patch
![image](https://user-images.githubusercontent.com/90168447/226803252-c99db3c5-14b8-41b4-8dad-7f24f4dcc20f.png)
