### PR TITLE
docs: append opts example to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,10 +665,12 @@ As part of a spec, you can add `import` statements to import additional plugin m
 Both of the `setup()` calls are equivalent:
 
 ```lua
-require("lazy").setup("plugins")
+opts = { defaults = { lazy = true } }
+
+require("lazy").setup("plugins", opts)
 
 -- Same as:
-require("lazy").setup({{import = "plugins"}})
+require("lazy").setup({{import = "plugins"}}, opts)
 ```
 
 To import multiple modules from a plugin, add additional specs for each import.
@@ -679,7 +681,10 @@ require("lazy").setup({
   spec = {
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
     { import = "lazyvim.plugins.extras.coding.copilot" },
-  }
+  },
+  defaults = {
+    lazy = true,
+  },
 )
 ```
 


### PR DESCRIPTION
This PR only adds some content to README.

As I have used the lazy.nvim for a long time. I was so confused why my options did not work when I changed them. 
After rereading the README and the source code, I found the setup part is a bit ambiguous in the doc.

So I add opts example to the `setup` part of README.