### PR TITLE
fix(render): show message if not yet committed

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -501,8 +501,6 @@ function M:details(plugin)
     end
     if git.commit then
       table.insert(props, { "commit", git.commit:sub(1, 7), "LazyCommit" })
-    else
-      table.insert(props, { "commit", "No commits yet" })
     end
   end
   if Util.file_exists(plugin.dir .. "/README.md") then

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -499,7 +499,11 @@ function M:details(plugin)
     if git.branch then
       table.insert(props, { "branch", git.branch })
     end
-    table.insert(props, { "commit", git.commit:sub(1, 7), "LazyCommit" })
+    if git.commit then
+      table.insert(props, { "commit", git.commit:sub(1, 7), "LazyCommit" })
+    else
+      table.insert(props, { "commit", "No commits yet" })
+    end
   end
   if Util.file_exists(plugin.dir .. "/README.md") then
     table.insert(props, { "readme", "README.md" })


### PR DESCRIPTION
When using a local plugin that has not yet been commited, the following error occurs when trying to view plugin information.
```
Error executing vim.schedule lua callback: ...local/share/nvim/lazy/lazy.nvim/lua/lazy/view/render.lua:502: attempt to index field 'commit' (a nil value)
stack traceback:
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/view/render.lua:502: in function 'details'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/view/render.lua:422: in function 'plugin'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/view/render.lua:239: in function 'section'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/view/render.lua:71: in function 'update'
        .../.local/share/nvim/lazy/lazy.nvim/lua/lazy/view/init.lua:142: in function 'fn'
        ...tsuuu/.local/share/nvim/lazy/lazy.nvim/lua/lazy/util.lua:72: in function <...tsuuu/.local/share/nvim/lazy/lazy.nvim/lua/lazy/util.lua:71>
```
So make it show `No commits yet` if `git.commit` is `nil`.