### PR TITLE
fix(core): use config.git.url_format to build the url for lazy.nvim.  Fixes #791

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -375,7 +375,7 @@ function M.load()
   -- load specs
   Util.track("spec")
   Config.spec = Spec.new()
-  Config.spec:parse({ vim.deepcopy(Config.options.spec), { url = "https://github.com/folke/lazy.nvim.git" } })
+  Config.spec:parse({ vim.deepcopy(Config.options.spec), { "folke/lazy.nvim" } })
 
   -- override some lazy props
   local lazy = Config.spec.plugins["lazy.nvim"]


### PR DESCRIPTION
Construct the lazy.nvim package's url string using the configured `git.url_format`.

Tested in normal configuration with access to GitHub, and in firewalled situation without GitHub access.