### PR TITLE
fix(health): false positive when checking for packer, plugged, paq

### DIFF
--- a/lua/lazy/health.lua
+++ b/lua/lazy/health.lua
@@ -38,7 +38,7 @@ function M.check()
 
   for _, name in ipairs({ "packer", "plugged", "paq" }) do
     for _, path in ipairs(vim.opt.rtp:get()) do
-      if path:find(name, 1, true) then
+      if path:find("/" .. name .. "/", 1, true) then
         error("Found paths on the rtp from another plugin manager `" .. name .. "`")
         break
       end


### PR DESCRIPTION
Not sure if it's worth it to make it any more robust, it still matches paths if the username is exactly packer, plugged or paq, but at least it's not matching at the substring level

Fixes https://github.com/folke/lazy.nvim/issues/798