### PR TITLE
docs: Add example of multiple plugin spec modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,19 @@ require("lazy").setup("plugins")
 require("lazy").setup({{import = "plugins"}})
 ```
 
+If you need to load plugins from multiple locations, such as for a global and
+a site-local Neovim configuration, you can do that with multiple import
+statements:
+
+```lua
+require("lazy").setup(
+	{
+		{ import = "plugins.global" },
+		{ import = "plugins.local" },
+	}
+)
+```
+
 To import multiple modules from a plugin, add additional specs for each import.
 For example, to import LazyVim core plugins and an optional plugin:
 


### PR DESCRIPTION
Adds an explicit example of how to import plugin specs from multiple locations.

The assumption here is you have a global Neovim configuration under `~/.config/nvim` and a site-local config under another directory, for example maybe `~/.config/nvim.local`. In `init.lua` you would add the local config to `rtp` and verify local plugins exist before loading `lazy.nvim`:

```lua
local local_config_path = vim.fn.expand("~/.config/nvim.local")
vim.opt.rtp:append(local_config_path)

-- Assumes global plugins are at ~/.config/nvim/lua/plugins/*.lua
local plugins_specs = {
  { import = "plugins" },
}

-- Assumes site-local plugins are at ~/.config/nvim.local/lua/local/plugins/*.lua
if vim.loop.fs_stat(local_config_path .. "/lua/local/plugins") then
  table.insert(plugins_specs, { import = local_config_path .. "/lua/local/plugins" })
end

require("lazy").setup(plugins_specs)
```

I left the example in the README as just two explicit modules since I assume people who need something like this already have their own utility function for conditionally doing things based on what's in the site-local configuration, but I can expand the README example or add another one with more detail like this under a `<details>` section if you want.