### PR TITLE
fix completion error

### DIFF
--- a/lua/lazy/view/commands.lua
+++ b/lua/lazy/view/commands.lua
@@ -112,7 +112,7 @@ function M.setup()
 
       ---@param key string
       return vim.tbl_filter(function(key)
-        return key:find(prefix) == 1
+        return key:find(prefix, 1, true) == 1
       end, vim.tbl_keys(M.commands))
     end,
   })


### PR DESCRIPTION
When Lazy commands are searched in command line mode, completion fails horribly (sometime crashing nvim entirely) when the partial string to complete contains non-escape characters.
For example, running `:Lazy up[` results in a crash.

The fix is to instruct string.find to perform a literal search, treating the string to search not as a regular expression.