### PR TITLE
docs: Add example for non-headless sync from CLI

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -621,6 +621,12 @@ example, if you want to sync lazy from the cmdline, you can use:
     $ nvim --headless "+Lazy! sync" +qa
 <
 
+If you want to do the above, but with the full nvim UI (instead of headless):
+
+>shell
+    $ nvim "+autocmd User VeryLazy Lazy! sync" +qa
+<
+
 `opts` is a table with the following key-values:
 
 - **wait**when true, then the call will wait till the operation completed


### PR DESCRIPTION
From this issue: https://github.com/folke/lazy.nvim/issues/285

Figured it's worth a quick callout in the docs to the alternative approach.