### PR TITLE
Initial packspec support

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -179,6 +179,11 @@ M.defaults = {
     -- Track each new require in the Lazy profiling tab
     require = false,
   },
+  packspec = {
+    enabled = true,
+    versions = true, -- Honor dependency versions in packspecs
+    path = vim.fn.stdpath("state") .. "/lazy/packspec.lua",
+  },
   debug = false,
 }
 
@@ -281,6 +286,14 @@ function M.setup(opts)
           require("lazy.manage.checker").start()
         end, 10)
       end
+
+      -- useful for plugin developers when making changes to a packspec file
+      vim.api.nvim_create_autocmd("BufWritePost", {
+        pattern = "package.lua",
+        callback = function()
+          require("lazy.view.commands").cmd("packspec")
+        end,
+      })
     end,
   })
 

--- a/lua/lazy/core/packspec.lua
+++ b/lua/lazy/core/packspec.lua
@@ -1,0 +1,125 @@
+local Config = require("lazy.core.config")
+local Util = require("lazy.util")
+
+---@class PackSpec
+---@field dependencies? table<string, string>
+---@field lazy? LazyPluginSpec
+local M = {}
+
+M.lazy_file = "lazy.lua"
+M.pkg_file = "pkg.json"
+M.enable_lazy_file = false
+
+---@alias LazyPkg {lazy?:(fun():LazySpec), pkg?:PackSpec}
+
+---@type table<string, LazyPkg>
+M.packspecs = nil
+---@type table<string, LazySpec>
+M.specs = {}
+
+---@param spec LazyPkg
+---@param plugin LazyPlugin
+---@return LazySpec?
+local function convert(plugin, spec)
+  ---@type LazySpec
+  local ret = {}
+
+  local pkg = spec.pkg
+  if pkg then
+    if pkg.dependencies then
+      for url, version in pairs(pkg.dependencies) do
+        if (not Config.options.packspec.versions) or version == "*" or version == "" then
+          version = nil
+        end
+        -- HACK: Add `.git` to github urls
+        if url:find("github") and not url:match("%.git$") then
+          url = url .. ".git"
+        end
+        ret[#ret + 1] = { url = url, version = version }
+      end
+    end
+    local p = pkg.lazy
+    if p then
+      p.url = p.url or plugin.url
+      p.dir = p.dir or plugin.dir
+      ret[#ret + 1] = p
+    end
+  end
+
+  if spec.lazy then
+    ret[#ret + 1] = spec.lazy()
+  end
+
+  return ret
+end
+
+local function load()
+  Util.track("packspec")
+  M.packspecs = {}
+  if vim.loop.fs_stat(Config.options.packspec.path) then
+    Util.try(function()
+      M.packspecs = loadfile(Config.options.packspec.path)()
+    end, "Error loading packspecs:")
+  end
+  Util.track()
+end
+
+---@param plugin LazyPlugin
+---@return LazySpec?
+function M.get(plugin)
+  if not M.packspecs then
+    load()
+  end
+
+  if not M.packspecs[plugin.dir] then
+    return
+  end
+  M.specs[plugin.dir] = M.specs[plugin.dir] or convert(plugin, M.packspecs[plugin.dir])
+  return vim.deepcopy(M.specs[plugin.dir])
+end
+
+function M.update()
+  local ret = {}
+  for _, plugin in pairs(Config.plugins) do
+    local spec = {
+      pkg = M.pkg(plugin),
+      lazy = M.enable_lazy_file and M.lazy_pkg(plugin) or nil,
+    }
+    if not vim.tbl_isempty(spec) then
+      ret[plugin.dir] = spec
+    end
+  end
+  local code = "return " .. Util.dump(ret)
+  Util.write_file(Config.options.packspec.path, code)
+  M.packspecs = nil
+  M.specs = {}
+end
+
+---@param plugin LazyPlugin
+function M.lazy_pkg(plugin)
+  local file = Util.norm(plugin.dir .. "/" .. M.lazy_file)
+  if Util.file_exists(file) then
+    ---@type LazySpec
+    local chunk = Util.try(function()
+      return loadfile(file)
+    end, "`" .. M.lazy_file .. "` for **" .. plugin.name .. "** has errors:")
+    if chunk then
+      return { _raw = ([[function() %s end]]):format(Util.read_file(file)) }
+    else
+      Util.error("Invalid `package.lua` for **" .. plugin.name .. "**")
+    end
+  end
+end
+
+---@param plugin LazyPlugin
+function M.pkg(plugin)
+  local file = Util.norm(plugin.dir .. "/" .. M.pkg_file)
+  if Util.file_exists(file) then
+    ---@type PackSpec
+    return Util.try(function()
+      return vim.json.decode(Util.read_file(file))
+    end, "`" .. M.pkg_file .. "` for **" .. plugin.name .. "** has errors:")
+  end
+end
+
+return M

--- a/lua/lazy/manage/init.lua
+++ b/lua/lazy/manage/init.lua
@@ -92,6 +92,7 @@ function M.install(opts)
   }, opts):wait(function()
     require("lazy.manage.lock").update()
     require("lazy.help").update()
+    require("lazy.core.packspec").update()
   end)
 end
 
@@ -116,6 +117,7 @@ function M.update(opts)
   }, opts):wait(function()
     require("lazy.manage.lock").update()
     require("lazy.help").update()
+    require("lazy.core.packspec").update()
   end)
 end
 --

--- a/lua/lazy/view/commands.lua
+++ b/lua/lazy/view/commands.lua
@@ -34,6 +34,20 @@ M.commands = {
   health = function()
     vim.cmd.checkhealth("lazy")
   end,
+  pkg = function(opts)
+    local Pkg = require("lazy.core.packspec")
+    Pkg.update()
+    require("lazy.manage.reloader").reload({
+      {
+        file = "packspec", --Config.options.packspec.path,
+        what = "changed",
+      },
+    })
+    for _, plugin in pairs(opts and opts.plugins or {}) do
+      local spec = Pkg.get(plugin)
+      Util.info(vim.inspect(spec), { lang = "lua", title = plugin.name })
+    end
+  end,
   home = function()
     View.show("home")
   end,
@@ -74,7 +88,7 @@ M.commands = {
 }
 
 function M.complete(cmd, prefix)
-  if not (ViewConfig.commands[cmd] or {}).plugins then
+  if not (ViewConfig.commands[cmd] or {}).plugins and cmd ~= "pkg" then
     return
   end
   ---@type string[]

--- a/tests/core/plugin_spec.lua
+++ b/tests/core/plugin_spec.lua
@@ -30,6 +30,14 @@ describe("plugin spec url/name", function()
     { { "foo/bar", name = "foobar" }, { [1] = "foo/bar", name = "foobar", url = "https://github.com/foo/bar.git" } },
     { { "foo/bar", url = "123" }, { [1] = "foo/bar", name = "123", url = "123" } },
     { { url = "https://foobar" }, { name = "foobar", url = "https://foobar" } },
+    {
+      { { url = "https://foo", name = "foobar" }, { url = "https://foo" } },
+      { name = "foobar", url = "https://foo" },
+    },
+    {
+      { { url = "https://foo" }, { url = "https://foo", name = "foobar" } },
+      { name = "foobar", url = "https://foo" },
+    },
     { { url = "ssh://foobar" }, { name = "foobar", url = "ssh://foobar" } },
     { "foo/bar", { [1] = "foo/bar", name = "bar", url = "https://github.com/foo/bar.git" } },
     { { { { "foo/bar" } } }, { [1] = "foo/bar", name = "bar", url = "https://github.com/foo/bar.git" } },
@@ -46,6 +54,7 @@ describe("plugin spec url/name", function()
       plugins[1]._ = {}
       assert(#spec.notifs == 0)
       assert.equal(1, #plugins)
+      plugins[1]._.super = nil
       assert.same(test[2], plugins[1])
     end)
   end


### PR DESCRIPTION
Initial support for `pkg.json` and `lazy.lua` files part of a plugin repo.

Goals:
- support the [pkg.json](https://github.com/nvim-lua/nvim-package-specification/issues/41) with a lazy extension in `lazy`
  - `lazy` can contain any valid lazy spec fields. They will be added to the plugin's spec.
- support a `lazy.lua` for more advanced use-cases. This file should return a lazy spec
  - Only use this if the `custom.lazy` field is not sufficient for your use-case.
  - **this functionality is currently disabled since it's not really needed**

There are two types of **dependencies** in lazy:
- **runtime dep** meaning that the dep should be loaded when the plugin loads
- **env dep** meaning that the dep should be installed in the user's environment
- lazy transforms the packspec dependencies to the second type to allow more flexibility for the plugin developer
- when version is `"*"` or `""`, the dependency is for the latest `HEAD`. `*` explicitly selects the latest stable version.
- `version` supports the npm semver range syntax, except for the combined ranges

On `install` or `update`, lazy combines all `package.lua` in a single cached file for better performance.

## Commands
- `:Lazy pkg`: reloads all `pkg.json` files. This is useful when developing a packspec for a plugin
- `:Lazy pkg plugin_name(s)`: additionally shows the resolved lazy spec based on the plugin's packspec

