### PR TITLE
fix: call getscriptinfo with no param

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -266,7 +266,7 @@ function M.reload(plugin)
   end
 
   -- reload any vimscript files for this plugin
-  local scripts = vim.fn.getscriptinfo({ name = ".vim" })
+  local scripts = vim.fn.getscriptinfo()
   local loaded_scripts = {}
   for _, s in ipairs(scripts) do
     ---@type string


### PR DESCRIPTION
as described in the doc, there is no param to call this function

https://github.com/neovim/neovim/blob/release-0.9/runtime/doc/builtin.txt#L3580