### PR TITLE
feat(plugins): Given an optional plugin, conditionally discard deps

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -184,6 +184,7 @@ function Spec:fix_cond()
   end
 end
 
+---@return string[]
 function Spec:fix_optional()
   local all_optional_deps = {}
   if not self.optional then
@@ -219,7 +220,7 @@ function Spec:fix_disabled()
   ---@type string[] dependencies of disabled plugins
   local disabled_deps = {}
 
-  ---@type string[] dependencies of plugins that are all optional
+  ---@type string[] dependencies of plugins that are completely optional
   local all_optional_deps = self:fix_optional()
   self:fix_cond()
 

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -240,7 +240,7 @@ function Spec:fix_disabled()
     end
   end
 
-  -- fix deps of plugins that are all optional
+  -- fix deps of plugins that are completely optional
   self:fix_dependencies(all_optional_deps, dep_of, function(dep_name)
     self.plugins[dep_name] = nil
   end)

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -146,6 +146,31 @@ function Spec:warn(msg)
   self:log(msg, vim.log.levels.WARN)
 end
 
+---@param gathered_deps string[]
+---@param dep_of table<string,string[]>
+---@param on_disable fun(string):nil
+function Spec:fix_dependencies(gathered_deps, dep_of, on_disable)
+  local function should_disable(dep_name)
+    for _, parent in ipairs(dep_of[dep_name] or {}) do
+      if self.plugins[parent] then
+        return false
+      end
+    end
+    return true
+  end
+
+  for _, dep_name in ipairs(gathered_deps) do
+    -- only check if the plugin is still enabled and it is a dep
+    if self.plugins[dep_name] and self.plugins[dep_name]._.dep then
+      -- check if the dep is still used by another plugin
+      if should_disable(dep_name) then
+        -- disable the dep when no longer needed
+        on_disable(dep_name)
+      end
+    end
+  end
+end
+
 function Spec:fix_cond()
   for _, plugin in pairs(self.plugins) do
     local cond = plugin.cond
@@ -209,27 +234,13 @@ function Spec:fix_disabled()
     end
   end
 
-  -- check deps of disabled plugins
-  for _, dep in ipairs(disabled_deps) do
-    -- only check if the plugin is still enabled and it is a dep
-    if self.plugins[dep] and self.plugins[dep]._.dep then
-      -- check if the dep is still used by another plugin
-      local keep = false
-      for _, parent in ipairs(dep_of[dep] or {}) do
-        if self.plugins[parent] then
-          keep = true
-          break
-        end
-      end
-      -- disable the dep when no longer needed
-      if not keep then
-        local plugin = self.plugins[dep]
-        plugin._.kind = "disabled"
-        self.plugins[plugin.name] = nil
-        self.disabled[plugin.name] = plugin
-      end
-    end
-  end
+  -- fix deps of disabled plugins
+  self:fix_dependencies(disabled_deps, dep_of, function(dep_name)
+    local plugin = self.plugins[dep_name]
+    plugin._.kind = "disabled"
+    self.plugins[plugin.name] = nil
+    self.disabled[plugin.name] = plugin
+  end)
 end
 
 ---@param msg string

--- a/tests/core/plugin_spec.lua
+++ b/tests/core/plugin_spec.lua
@@ -273,6 +273,25 @@ describe("plugin spec opt", function()
       end
     end
   end)
+
+  it("handles the optional keyword", function()
+    local tests = {
+      [{ { "foo/bax" }, { "foo/bar", optional = true, dependencies = "foo/dep1" } }] = false,
+      [{ { "foo/bax", dependencies = "foo/dep1" }, { "foo/bar", optional = true, dependencies = "foo/dep1" } }] = true,
+    }
+    for test, ret in pairs(tests) do
+      local spec = Plugin.Spec.new(test)
+      assert(#spec.notifs == 0)
+      assert(spec.plugins.bax)
+      assert(not spec.plugins.bar)
+      assert(#spec.disabled == 0)
+      if ret then
+        assert(spec.plugins.dep1)
+      else
+        assert(not spec.plugins.opt1)
+      end
+    end
+  end)
 end)
 
 describe("plugin opts", function()


### PR DESCRIPTION
Currently, when a plugin is marked with "enabled = false", lazy.nvim investigates the dependencies of that plugin,and disables them when appropriate.
Such behaviour is not implemented for a plugin marked with "optional = true".

## Example

Consider a stock LazyVim installation with "extras/lang/python" added to "config/lazy.lua"
The resulting installation includes nvim-dap-python and its keys, but without nvim-dap installed.

Pressing `<leader> d P c` leads to an error.
The UI of which-key shows "prefix" as description for "d".

## The cause

In "extras/lang/python", nvim-dap-python is a dependency of nvim-dap.
When "extras/dap/core" is not added to "config/lazy.lua", nvim-dap becomes completely optional and will not be installed.
Currently, the dependency of nvim-dap, nvim-dap-python, does get installed.

**Note**: This pattern applies to multiple configs in extras.

## Is it a problem?

If the user wants to use "extras/lang/python" without "extras/dap/core", the following options are available:

- the user accepts a plugin he has no benefit of.
  The plugin will never load, unless the aforementioned keys are pressed, resulting in an error.
- the user explicitly disables nvim-dap-python
- the maintainer moves nvim-dap to its own python specific config.
  The user now needs to include both python configs for complete functionality.

## Implementation

This is relatively straightforward, reusing the existing algorithm doing the disabling of explicitly disabled plugins.

- The user might see some unexpected plugins to be cleaned in the UI of lazy.nvim.
- Performance is not expected to degrade. I did not observe a decline.

## References

- [discussion dependency inheritance](https://github.com/folke/lazy.nvim/discussions/817)
- [Optional keyword added](https://github.com/LazyVim/LazyVim/pull/640)
