### PR TITLE
Adding option for git shallow clone

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,3 @@
+{
+    "workspace.checkThirdParty": false
+}

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,3 +1,0 @@
-{
-    "workspace.checkThirdParty": false
-}

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -67,12 +67,12 @@ M.clone = {
       self.plugin.url,
     }
 
-    if self.plugin.shallow ~= false then
-       args[#args+1] = "--depth=1"
-    end
-
     if Config.options.git.filter then
       args[#args + 1] = "--filter=blob:none"
+    end
+
+    if self.plugin.shallow ~= false then
+       args[#args+1] = "--depth=1"
     end
 
     if self.plugin.submodules ~= false then

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -67,6 +67,10 @@ M.clone = {
       self.plugin.url,
     }
 
+    if self.plugin.shallow ~= false then
+       args[#args+1] = "--depth=1"
+    end
+
     if Config.options.git.filter then
       args[#args + 1] = "--filter=blob:none"
     end

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -32,6 +32,7 @@
 ---@field module? false
 
 ---@class LazyPluginRef
+---@field shallow? boolean clones the plugin with --depth=1
 ---@field branch? string
 ---@field tag? string
 ---@field commit? string


### PR DESCRIPTION
Adding a option to the plugin definition so the user can specify if he want's the whole git repository or just the latest revision. This can be useful when having low internet connections or for keeping storage footprint low. I actually don't now if this would break something, as far as i understand this won't change the current process and will add an optional way of cloning plugins. I don't code that much in Lua please feel free to ask for any code changes.