### PR TITLE
Fix doc missing bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,7 @@ require("lazy").setup({
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
     { import = "lazyvim.plugins.extras.coding.copilot" },
   }
-)
+})
 ```
 
 When you import specs, you can override them by simply adding a spec for the same plugin to your local


### PR DESCRIPTION
Thanks for your generous guide in #959 , I have read the CI workflow configuration and found that changing `README.md` is actually what I should do.

I have tested this by merge this branch in my fork repo, and it triggered [doc generation](https://github.com/DistinctWind/lazy.nvim-fix-doc-typo/commit/f43331720a53e720c6472077f2fae84736bc19e0) correctly.

---

感谢你在 #959 中的慷慨指导，我阅读了这个项目的CI工作流配置，发现修改`README.md`才是我应该做的。

在镜像仓库中合并该分支，发现确实正确触发了[文档自动生成](https://github.com/DistinctWind/lazy.nvim-fix-doc-typo/commit/f43331720a53e720c6472077f2fae84736bc19e0)。