### PR TITLE
Make commit pattern more accurate

### DIFF
--- a/lua/lazy/view/init.lua
+++ b/lua/lazy/view/init.lua
@@ -159,7 +159,7 @@ function M:open_url(path)
 end
 
 function M:setup_patterns()
-  local commit_pattern = "%f[%w](" .. string.rep("%w", 7) .. ")%f[%W]"
+  local commit_pattern = "%f[%w](" .. string.rep("[a-f0-9]", 7) .. ")%f[%W]"
   self:on_pattern(ViewConfig.keys.hover, {
     [commit_pattern] = function(hash)
       self:diff({ commit = hash, browser = true })


### PR DESCRIPTION
Sometimes when hovering over updated plugins and triggering `diff` with `d` key, I get an empty `diff` view. I traced the problem to a very generic `commit_pattern` which currently matches any alphanumeric sequence of 7 characters surrounded by "word boundary" / frontier patterns. I adjusted the regex to match only `[a-z0-9] * 7` which should make this issue appear less. I am keeping the older frontier sets `%f[%w]` and `%f[%W]` because if I switch to `%f[a-f0-9]` and `%f[^0-9a-f]` I will be matching strings like `zzz1234567xxx`.