### PR TITLE
feat(core): If a plugin is not enabled, ignore all specs in its dependencies

### DIFF
--- a/tests/core/plugin_spec.lua
+++ b/tests/core/plugin_spec.lua
@@ -337,7 +337,7 @@ describe("plugin opts", function()
 end)
 
 describe("plugin spec", function()
-  it("discards contributions from unused plugins", function()
+  it("only includes partials from enabled plugins", function()
     local tests = {
       {
         spec = {

--- a/tests/core/plugin_spec.lua
+++ b/tests/core/plugin_spec.lua
@@ -335,3 +335,32 @@ describe("plugin opts", function()
     end
   end)
 end)
+
+describe("plugin spec", function()
+  it("discards contributions from unused plugins", function()
+    local tests = {
+      {
+        spec = {
+          { "foo/disabled", enabled = false, dependencies = { "foo/bar", opts = { key_disabled = true } } },
+          { "foo/disabled", dependencies = { "foo/bar", opts = { key_disabled_two = true } } },
+          { "foo/conditional", cond = false, dependencies = { "foo/bar", opts = { key_cond = true } } },
+          { "foo/optional", optional = true, dependencies = { "foo/bar", opts = { key_optional = true } } },
+          { "foo/active", dependencies = { "foo/bar", opts = { key_active = true } } },
+          {
+            "foo/bar",
+            opts = { key = true },
+          },
+        },
+        expected_opts = { key = true, key_active = true },
+      }, -- for now, one test...
+    }
+    for _, test in ipairs(tests) do
+      local spec = Plugin.Spec.new(test.spec)
+      assert(#spec.notifs == 0)
+      assert(vim.tbl_count(spec.plugins) == 2)
+      assert(spec.plugins.active)
+      assert(spec.plugins.bar)
+      assert.same(test.expected_opts, Plugin.values(spec.plugins.bar, "opts"))
+    end
+  end)
+end)


### PR DESCRIPTION
Example scenario:

```lua
return {
  {
    "A",
    opts = {
      foo = true,
    },
  },
  {
    "B",
    enabled = false,
    dependencies = {
      {
        "A",
        keys = {
          { "<leader>ab", function() require("A").needing_B() end, desc = "AB" }
        }
        opts = {
          bar = true,
        },
      },
    },
  },
}
```

Plugin B is `disabled`.
However, _both_ definitions of A are merged into the final A:

- `A.opts == { foo = true, bar = true }`
- key `<leader>ab` is present, and will fail when invoked, on the absence of B.

Note that currently, when A would _only_ exist as a dependency of B, plugin A would have been `disabled` as well.

The configuration of a plugin can depend on the presence of another plugin.
A good example is the conditional definition of a key.
Currently, extra code is required, checking for the presence of a plugin using programmatic "guards".

This PR ensures that plugin A _only_ contains the definition provided by plugin B, if B is `enabled`.
The result becomes:

- `A.opts == { foo = true }`
- key `<leader>ab` is not available.

#### An opinion on the benefits

- it's easier to configure specs on a need to have basis
- specs are easier to reason about

#### An opinion on the implications

This PR will most likely not break existing personal configurations.
Users might have expected the behaviour this PR aims for to already be in effect.

Distributions however are highly modularized by nature. Maintainers are advised to inspect the code.
Consider a definition of A inside B, containing a property that should always be present on A regardless of the status of B.

Breaking example:

```lua
return {
  {
    "A",
    opts = {
      foo = true,
    },
  },
  {
    "B",
    enabled = false,
    dependencies = {
      {
        "A",
        opts = {
          ALWAYS_NEEDED = true, -- BREAKING, not present anymore!
        },
      },
    },
  },
}
```

In this case, it would make sense to move the configuration of property `ALWAYS_NEEDED` to the top-level spec of plugin A.

#### Approach

This PR changes the `Plugin.parse` method, after all specs have been normalized.
An `enabled` plugin will be repaired when it contains a spec originating from the `dependencies` property of a plugin that is _not_ `enabled`.

The `enabled` plugin can be repaired by redoing its `merge` operation, using a filter on its individual plugin definitions.

I did not observe a noticeable decline in performance.
When the user disables many plugins that have specs in their `dependencies`, some performance overhead is expected.

### Additional context

AstroNvim's lead developer proposed the idea in this [discussion](https://github.com/folke/lazy.nvim/discussions/949#discussion-5432217). Thanks @mehalter, for all the support!

A scenario illustrating the effect of the proposed changes is discussed in the code review of the following PR: [enable telescope extension of nvim-notify](https://github.com/LazyVim/LazyVim/pull/1306#discussion_r1289746423).

Worth mentioning: An explanation on how dependencies are loaded, written by Folke in this [issue](https://github.com/LazyVim/LazyVim/issues/283#issuecomment-1433633320).

While investigating existing issues, I found an issue from @UtkarshVerma, also addressing the topic: [Don't process dependencies if spec is disabled](https://github.com/folke/lazy.nvim/issues/868).
