### PR TITLE
fix: ensure ui closed after installing missing plugins

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -3,6 +3,7 @@ local Config = require("lazy.core.config")
 local Handler = require("lazy.core.handler")
 local Plugin = require("lazy.core.plugin")
 local Cache = require("lazy.core.cache")
+local View = require("lazy.view")
 
 ---@class LazyCoreLoader
 local M = {}
@@ -45,8 +46,12 @@ function M.setup()
         break
       end
     end
+    if View.visible() then
+      View.view:close()
+    end
     Util.track()
   end
+
   Config.mapleader = vim.g.mapleader
 
   -- report any warnings & errors


### PR DESCRIPTION
Problem: When installing missing plugins, sometimes the UI is not properly closed when the install finishes. This leaves a listed but empty buffer and messes with settings (the video shows statuscolumns disappearing, etc.).

Solution: After the missing plugin install step is complete, check that the view is closed, and close it if it's still open.

Before:

https://github.com/folke/lazy.nvim/assets/38540736/70f18b7d-9828-48de-91e9-c4a7ca23311d

After:

https://github.com/folke/lazy.nvim/assets/38540736/14cc5547-3883-42c8-bb44-3c9a55fc7f15

