### PR TITLE
docs(readme): note when lua/plugins/*.lua loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ return {
 }
 ```
 
-- Any lua file in `~/.config/nvim/lua/plugins/*.lua` will be automatically merged in the main plugin spec
+- Any lua file in `~/.config/nvim/lua/plugins/*.lua` will be automatically merged in the main plugin spec if using `.setup("plugins")`.
 
 For a real-life example, you can check [LazyVim](https://github.com/LazyVim/LazyVim) and more specifically:
 


### PR DESCRIPTION
I thought these files were always loaded, even if your main plugin specs were in a plugins table. However it seems you need to switch to the filesystem method for this to work. That makes sense, but could be clearer in the doc.