### PR TITLE
docs(readme): set origin when bootstrapping lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ if not vim.loop.fs_stat(lazypath) then
     "git",
     "clone",
     "--filter=blob:none",
+    "--origin=origin",
     "https://github.com/folke/lazy.nvim.git",
     "--branch=stable", -- latest stable release
     lazypath,


### PR DESCRIPTION
If you set a different default remote in your global git config, e.g.

```
[clone]
  defaultRemoteName = "up"
```

then the default git command clones using that remote, which confuses lazy.nvim's update system later.

Looks like actual plugins are handled properly.