### PR TITLE
fix(float): disable signcolumn

### DIFF
--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -131,6 +131,7 @@ function M:mount()
     Util.wo(self.win, "wrap", true)
     Util.wo(self.win, "winhighlight", "Normal:LazyNormal")
     Util.wo(self.win, "colorcolumn", "")
+    Util.wo(self.win, "signcolumn", "no")
   end
   opts()
 


### PR DESCRIPTION
I don't think these floating windows should ever show signs anyway.