### PR TITLE
Fix: Vim scripts loaded on Unix systems, when `git config --global core.autocrlf`, fail to load

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,11 @@ return {
     -- then set the below to false. This should work, but is NOT supported and will
     -- increase downloads a lot.
     filter = true,
+    -- If git config --global core.autocrlf is true on a Unix/Linux system, then the git clone process
+    -- will give files with CRLF endings. Vi / vim / neovim cannot handle this when loading .vim scripts.
+    -- When true, Lazy will force git to clone with core.autocrlf=false. When false, Lazy will not
+    -- touch the core.autocrlf setting.
+    override_autocrlf = true,
   },
   dev = {
     -- directory where you store your local plugin projects

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -28,6 +28,11 @@ M.defaults = {
     -- then set the below to false. This should work, but is NOT supported and will
     -- increase downloads a lot.
     filter = true,
+    -- If git config --global core.autocrlf is true on a Unix/Linux system, then the git clone
+    -- process will lead to files with CRLF endings. Vi / vim / neovim cannot handle this.
+    -- When true, Lazy will force git to clone with core.autocrlf=false. When false, Lazy will
+    -- not touch the core.autocrlf setting.
+    force_autocrlf = true,
   },
   dev = {
     -- directory where you store your local plugin projects

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -32,7 +32,7 @@ M.defaults = {
     -- process will lead to files with CRLF endings. Vi / vim / neovim cannot handle this.
     -- When true, Lazy will force git to clone with core.autocrlf=false. When false, Lazy will
     -- not touch the core.autocrlf setting.
-    force_autocrlf = true,
+    override_autocrlf = true,
   },
   dev = {
     -- directory where you store your local plugin projects

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -67,10 +67,13 @@ M.clone = {
       self.plugin.url,
     }
 
-    vim.print("force_autocrlf = " .. tostring(Config.options.git.force_autocrlf))
-
     if Config.options.git.filter then
       args[#args + 1] = "--filter=blob:none"
+    end
+
+    if Config.options.git.override_autocrlf == true then
+      args[#args + 1] = "-c"
+      args[#args + 1] = "core.autocrlf=false"
     end
 
     if self.plugin.submodules ~= false then

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -67,6 +67,8 @@ M.clone = {
       self.plugin.url,
     }
 
+    vim.print("force_autocrlf = " .. tostring(Config.options.git.force_autocrlf))
+
     if Config.options.git.filter then
       args[#args + 1] = "--filter=blob:none"
     end


### PR DESCRIPTION
Fixes #1025 (See note: https://github.com/folke/lazy.nvim/issues/1025#issuecomment-1739977380)

Added the config option `git.override_autocrlf`, with a default of true, which forces `config.autocrlf=false` when cloning repos. Tested on Windows and Ubuntu. 

To verify:

1. Set `git config --global core.autocrlf true`
2. `nvim -u repro.lua repro.lua`
4. Since `override_autocrlf` was not overridden and the default is true, neo_tree loads without error on both Windows and Linux. Note that `.repro/plugins/neo_tree.nvim/plugin/neo-tree.vim` has LF line endings.
6. `rm -rf .repro`
7. Modify `repro.lua` and remove the comment around `override_autocrlf = false`
8. `nvim -u repro.lua repro.lua`
9. On Linux, neo-tree will fail to load. On Windows, neo-tree will load fine. Note that `.repro/plugins/neo_tree.nvim/plugin/neo-tree.vim` has CRLF line endings.

Thanks!

```lua
-- repro.lua
local root = vim.fn.fnamemodify("./.repro", ":p")

-- set stdpaths to use .repro
for _, name in ipairs({ "config", "data", "state", "cache" }) do
	vim.env[("XDG_%s_HOME"):format(name:upper())] = root .. "/" .. name
end

-- bootstrap lazy
local lazypath = root .. "/plugins/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
	vim.fn.system({
		"git",
		"clone",
		"--filter=blob:none",
		"--single-branch",
		"https://github.com/JL102/lazy.nvim.git",
		lazypath,
	})
end
vim.opt.runtimepath:prepend(lazypath)

-- install plugins
local plugins = {
	-- do not remove the colorscheme!
	"folke/tokyonight.nvim",
	-- add any other pugins here
	{
		"nvim-neo-tree/neo-tree.nvim",
		branch = "v3.x",
		dependencies = {
			"nvim-lua/plenary.nvim",
			"nvim-tree/nvim-web-devicons", -- not strictly required, but recommended
			"MunifTanjim/nui.nvim",
		},
	},
}
require("lazy").setup(plugins, {
	root = root .. "/plugins",
	git = {
--		override_autocrlf = false,
	},
})

-- add anything else here
vim.opt.termguicolors = true
-- do not remove the colorscheme!
vim.cmd([[colorscheme tokyonight]])
```