### PR TITLE
vim.loop was replaced by vim.uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can add the following Lua code to your `init.lua` to bootstrap **lazy.nvim**
 
 ```lua
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   vim.fn.system({
     "git",
     "clone",


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/24376

vim.loop gives a deprecation warning