### PR TITLE
feat: on conditional disable, do not import additional plugin modules

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -380,6 +380,9 @@ function Spec:import(spec)
   if vim.tbl_contains(self.modules, spec.import) then
     return
   end
+  if spec.cond == false or (type(spec.cond) == "function" and not spec.cond()) then
+    return
+  end
   if spec.enabled == false or (type(spec.enabled) == "function" and not spec.enabled()) then
     return
   end

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -75,3 +75,4 @@
 ---@class LazySpecImport
 ---@field import string spec module to import
 ---@field enabled? boolean|(fun():boolean)
+---@field cond? boolean|(fun():boolean)


### PR DESCRIPTION
Example:
```lua
{
    {
      "folke/tokyonight.nvim",
      lazy = true,
      opts = { style = "moon" },
    },

    {
      "LazyVim/LazyVim",
      priority = 10000,
      lazy = false,
      opts = {
        colorscheme = "tokyonight",
      },
      version = "*",
      import = "lazyvim.plugins",
      -- cond = false,
      enabled = false,
    },
}
```

In this scenario, the `LazyVim` plugin is disabled, and the modules in `lazyvim.plugins` are not loaded.
However, when using `cond = false`, the modules in `lazyvim.plugins` are loaded, disregarding the `cond` setting.

For the [`lazyflex`](https://github.com/abeldekat/lazyflex.nvim) plugin, it makes sense to enable/disable the plugin using `cond`. 
In issue [Simpify installation instructions](https://github.com/abeldekat/lazyflex.nvim/issues/13) the motivation for this PR is described.

This PR adds a check on `cond` to `lazy.core.plugin`, method `Spec:import(spec)`.

I tested the changes using my lazy starter fork, see [`config.lazy`](https://github.com/abeldekat/starter/blob/71ba603f105632e728ec1154d04361ea2d7e0f96/lua/config/lazy.lua#L42).
