### PR TITLE
fix(manage): prevend auto conversion 'CRLF' to 'LF'. Fixes #1093

### DIFF
--- a/lua/lazy/manage/lock.lua
+++ b/lua/lazy/manage/lock.lua
@@ -9,7 +9,7 @@ M._loaded = false
 
 function M.update()
   vim.fn.mkdir(vim.fn.fnamemodify(Config.options.lockfile, ":p:h"), "p")
-  local f = assert(io.open(Config.options.lockfile, "w"))
+  local f = assert(io.open(Config.options.lockfile, "wb"))
   f:write("{\n")
   M.lock = {}
 


### PR DESCRIPTION
Fixes #1093
- fix(manage): preveng auto conversion 'CRLF' to 'LF' in update lazy-lock.json on Windows.