### PR TITLE
docs: icon for require without nerd font

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ return {
       keys = "🗝",
       plugin = "🔌",
       runtime = "💻",
+      require = "🌙",
       source = "📄",
       start = "🚀",
       task = "📌",


### PR DESCRIPTION
Recent update introduced feature that shows requirements by lua code. This PR improves docs by adding icon for `require` without nerd font.