### PR TITLE
feat(keys): include custom keys in help menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,22 +371,27 @@ return {
     browser = nil, ---@type string?
     throttle = 20, -- how frequently should the ui process render events
     custom_keys = {
-      -- you can define custom key maps here.
-      -- To disable one of the defaults, set it to false
+      -- You can define custom key maps here. If present, the description will
+      -- be shown in the help menu.
+      -- To disable one of the defaults, set it to false.
 
-      -- open lazygit log
-      ["<localleader>l"] = function(plugin)
-        require("lazy.util").float_term({ "lazygit", "log" }, {
-          cwd = plugin.dir,
-        })
-      end,
+      ["<localleader>l"] = {
+        function(plugin)
+          require("lazy.util").float_term({ "lazygit", "log" }, {
+            cwd = plugin.dir,
+          })
+        end,
+        desc = "Open lazygit log",
+      },
 
-      -- open a terminal for the plugin dir
-      ["<localleader>t"] = function(plugin)
-        require("lazy.util").float_term(nil, {
-          cwd = plugin.dir,
-        })
-      end,
+      ["<localleader>t"] = {
+        function(plugin)
+          require("lazy.util").float_term(nil, {
+            cwd = plugin.dir,
+          })
+        end,
+        desc = "Open terminal in plugin dir",
+      },
     },
   },
   diff = {

--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -473,22 +473,27 @@ CONFIGURATION                              *lazy.nvim-lazy.nvim-configuration*
         browser = nil, ---@type string?
         throttle = 20, -- how frequently should the ui process render events
         custom_keys = {
-          -- you can define custom key maps here.
-          -- To disable one of the defaults, set it to false
-    
-          -- open lazygit log
-          ["<localleader>l"] = function(plugin)
-            require("lazy.util").float_term({ "lazygit", "log" }, {
-              cwd = plugin.dir,
-            })
-          end,
-    
-          -- open a terminal for the plugin dir
-          ["<localleader>t"] = function(plugin)
-            require("lazy.util").float_term(nil, {
-              cwd = plugin.dir,
-            })
-          end,
+          -- You can define custom key maps here. If present, the description will
+          -- be shown in the help menu.
+          -- To disable one of the defaults, set it to false.
+
+          ["<localleader>l"] = {
+            function(plugin)
+              require("lazy.util").float_term({ "lazygit", "log" }, {
+                cwd = plugin.dir,
+              })
+            end,
+            desc = "Open lazygit log",
+          },
+
+          ["<localleader>t"] = {
+            function(plugin)
+              require("lazy.util").float_term(nil, {
+                cwd = plugin.dir,
+              })
+            end,
+            desc = "Open terminal in plugin dir",
+          },
         },
       },
       diff = {

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -81,22 +81,27 @@ M.defaults = {
     browser = nil, ---@type string?
     throttle = 20, -- how frequently should the ui process render events
     custom_keys = {
-      -- you can define custom key maps here.
-      -- To disable one of the defaults, set it to false
+      -- You can define custom key maps here. If present, the description will
+      -- be shown in the help menu.
+      -- To disable one of the defaults, set it to false.
 
-      -- open lazygit log
-      ["<localleader>l"] = function(plugin)
-        require("lazy.util").float_term({ "lazygit", "log" }, {
-          cwd = plugin.dir,
-        })
-      end,
+      ["<localleader>l"] = {
+        function(plugin)
+          require("lazy.util").float_term({ "lazygit", "log" }, {
+            cwd = plugin.dir,
+          })
+        end,
+        desc = "Open lazygit log",
+      },
 
-      -- open a terminal for the plugin dir
-      ["<localleader>t"] = function(plugin)
-        require("lazy.util").float_term(nil, {
-          cwd = plugin.dir,
-        })
-      end,
+      ["<localleader>t"] = {
+        function(plugin)
+          require("lazy.util").float_term(nil, {
+            cwd = plugin.dir,
+          })
+        end,
+        desc = "Open terminal in plugin dir",
+      },
     },
   },
   diff = {

--- a/lua/lazy/view/init.lua
+++ b/lua/lazy/view/init.lua
@@ -121,9 +121,10 @@ function M.create()
     end
   end)
 
-  for key, handler in pairs(Config.options.ui.custom_keys) do
-    if handler then
-      self:on_key(key, function()
+  for lhs, rhs in pairs(Config.options.ui.custom_keys) do
+    if rhs then
+      local handler = type(rhs) == "table" and rhs[1] or rhs
+      self:on_key(lhs, function()
         local plugin = self.render:get_plugin()
         if plugin then
           handler(plugin)

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -209,6 +209,14 @@ function M:help()
       self:append(" " .. (mode.desc_plugin or mode.desc)):nl()
     end
   end
+  for lhs, rhs in pairs(Config.options.ui.custom_keys) do
+    if type(rhs) == "table" and rhs.desc then
+      self:append("- ", "LazySpecial", { indent = 2 })
+      self:append("Custom key ", "Title")
+      self:append(lhs, "LazyProp")
+      self:append(" " .. rhs.desc):nl()
+    end
+  end
 end
 
 function M:progressbar()


### PR DESCRIPTION
Adds an optional description to custom keys. When present, the key is listed in the help menu.

This is how it looks:
<img width="867" alt="image" src="https://github.com/folke/lazy.nvim/assets/62502207/3f92f0bf-d9f6-4d79-9af0-aa034b10dff7">
