### PR TITLE
fix(loader): when reloading, clear plugin properties cache

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -216,6 +216,9 @@ function M.deactivate(plugin)
   -- disable handlers
   Handler.disable(plugin)
 
+  -- clear plugin properties cache
+  plugin._.cache = nil
+
   -- remove loaded lua modules
   Util.walkmods(plugin.dir .. "/lua", function(modname)
     package.loaded[modname] = nil


### PR DESCRIPTION
See #445

Some options and properties of plugin was not reloaded after `:Lazy reload <plugin>`, because the old version was preserved in cache.