### PR TITLE
feat: support dev.path as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ return {
     filter = true,
   },
   dev = {
-    -- directory where you store your local plugin projects
+    ---@type string | fun(plugin: LazyPlugin): string directory where you store your local plugin projects
     path = "~/projects",
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -30,7 +30,7 @@ M.defaults = {
     filter = true,
   },
   dev = {
-    -- directory where you store your local plugin projects
+    ---@type string | fun(plugin: LazyPlugin): string directory where you store your local plugin projects
     path = "~/projects",
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
@@ -213,7 +213,9 @@ function M.setup(opts)
   table.insert(M.options.install.colorscheme, "habamax")
 
   M.options.root = Util.norm(M.options.root)
-  M.options.dev.path = Util.norm(M.options.dev.path)
+  if type(M.options.dev.path) == "string" then
+    M.options.dev.path = Util.norm(M.options.dev.path)
+  end
   M.options.lockfile = Util.norm(M.options.lockfile)
   M.options.readme.root = Util.norm(M.options.readme.root)
 

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -106,11 +106,16 @@ function Spec:add(plugin, results)
   end
 
   -- dev plugins
-  if
-    plugin.dev
-    and (not Config.options.dev.fallback or vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1)
-  then
-    dir = Config.options.dev.path .. "/" .. plugin.name
+  if plugin.dev then
+    local dir_dev
+    if type(Config.options.dev.path) == "string" then
+      dir_dev = Config.options.dev.path .. "/" .. plugin.name
+    else
+      dir_dev = Util.norm(Config.options.dev.path(plugin))
+    end
+    if not Config.options.dev.fallback or vim.fn.isdirectory(dir_dev) == 1 then
+      dir = dir_dev
+    end
   elseif plugin.dev == false then
     -- explicitely select the default path
     dir = Config.options.root .. "/" .. plugin.name


### PR DESCRIPTION
In some case, `dev.path .. plugin.name` is not enoguh.

For example, when using `ghq` to manage projects, plugin directories may vary by owners of the plugins.

With this change, users can do something like below

``` lua
require("lazy").setup("plugins", {
  dev = {
    path = function(plugin)
      -- ghq
      local path, cnt = string.gsub(plugin.url, "^https://(.*)%.git$", "~/ghq/%1")
      if cnt == 1 then
        return path
      end

      -- fallback to default
      return "~/projects/" .. plugin.name
    end,
  },
})
```