### PR TITLE
fix: properly highlight breaking change commit scope

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -475,7 +475,7 @@ function M:log(task)
       self:append(vim.trim(msg), dimmed and "LazyDimmed" or nil):highlight({
         ["#%d+"] = "LazyCommitIssue",
         ["^%S+:"] = dimmed and "Bold" or "LazyCommitType",
-        ["^%S+(%(.*%)):"] = "LazyCommitScope",
+        ["^%S+(%(.*%))!?:"] = "LazyCommitScope",
         ["`.-`"] = "@text.literal.markdown_inline",
         ["%*.-%*"] = "Italic",
         ["%*%*.-%*%*"] = "Bold",


### PR DESCRIPTION
Before, something like `feat(perl)!:` would not have `(perl)` italicized due to the exclamation point at the end. This PR allows for such commits to have italicized scope as well.