### PR TITLE
feat: LazyKeysBase Support opts and rhs_maker

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -167,7 +167,8 @@ end
 ---@param plugins string|LazyPlugin|string[]|LazyPlugin[]
 ---@param reason {[string]:string}
 ---@param opts? {force:boolean} when force is true, we skip the cond check
-function M.load(plugins, reason, opts)
+---@param afterload? function a function that runs after load
+function M.load(plugins, reason, opts, afterload)
   ---@diagnostic disable-next-line: cast-local-type
   plugins = (type(plugins) == "string" or plugins.name) and { plugins } or plugins
   ---@cast plugins (string|LazyPlugin)[]
@@ -185,6 +186,9 @@ function M.load(plugins, reason, opts)
     end
     if plugin and not plugin._.loaded then
       M._load(plugin, reason, opts)
+      if afterload then
+       afterload()
+      end
     end
   end
 end


### PR DESCRIPTION
I add 2 field to LazyKeysBase
`opts`, a table of key options for vim.keymap.set.
`rhs_maker`, a function that returns a rhs. run after plugin loads, it could produce rhs dynamically.

Example:
```lua
---@class LazySpec
local M={}
M[1]="akinsho/bufferline.nvim"
local opts={noremap=true,nowait=true}
M.keys={
 {
  [1]="<leader>bp", --lhs
  opts=opts,
  desc="Bufferline Pick",
 },
 {
  [1]="<leader>b...",
  opts=opts, -- We can reuse opts
  desc="Bufferline ...",
 },
}
local key=M.keys[1]
key[2]=require("bufferline").pick
-- Module "bufferline" not found, because it is lazy.

key[2]=function() require("bufferline").pick() end
-- It works, but NOT elegant, it will require("bufferline") multiple time.

key.rhs_maker=function()
 return require("bufferline").pick -- Perfect!
end
-- rhs_maker returns a rhs and it will run after plugin load, and it could produce a rhs dynamically.
```