### PR TITLE
fix: catch errors setting up rtp when plugin not installed

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -472,7 +472,18 @@ function M.add_to_rtp(plugin)
     table.insert(rtp, idx_after or (#rtp + 1), after)
   end
 
-  vim.opt.rtp = rtp
+  local ok, result = pcall(function()
+    vim.opt.rtp = rtp
+  end)
+  if not ok then
+    -- Often gets E5108 when plugins aren't installed, but it's
+    -- inconsistent.
+    vim.notify(
+      "Unable to add rtp for " .. plugin.name .. ". Error message: " .. result,
+      vim.log.levels.WARN,
+      { title = "lazy.nvim" }
+    )
+  end
 end
 
 function M.source(path)


### PR DESCRIPTION
I was getting E5108 sometimes when a plugin that loads on `start` wasn't installed. That interrupted Lazy's load, preventing me from then using it to install the missing plugin.
On Windows it happened every time, on Linux it was about every 2nd time.

I'm hoping I've figured out enough of the codebase conventions for this to be written appropriately, but it was only a quick skim so apologies if I've missed an internal logging function.