### PR TITLE
fix(keys): fix abbreviation trigger on lazy load (#1218)

### DIFF
--- a/lua/lazy/core/handler/keys.lua
+++ b/lua/lazy/core/handler/keys.lua
@@ -123,6 +123,9 @@ function M:_add(keys)
         self:_set(keys, buf)
       end
 
+      if keys.mode:sub(-1) == 'a' then
+        lhs = lhs .. '<C-]>'
+      end
       local feed = vim.api.nvim_replace_termcodes("<Ignore>" .. lhs, true, true, true)
       -- insert instead of append the lhs
       vim.api.nvim_feedkeys(feed, "i", false)


### PR DESCRIPTION
If the keymap is an abbreviation, just adding an explicit trigger solves the issues (`:h i_CTRL-]`)