### PR TITLE
Added performance.rtp.custom_config_dir and dev.extra_paths options for nix compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ return {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
+    -- you may also include a list of paths to also check.
+    extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
     fallback = false, -- Fallback to git when local plugin doesn't exist

--- a/README.md
+++ b/README.md
@@ -436,6 +436,10 @@ return {
         -- "tutor",
         -- "zipPlugin",
       },
+      -- to work around circumstances in which your config folder is
+      -- not in the normal location when performance.rtp.reset = true
+      -- such as when loading your config folder from the nix store.
+      custom_config_dir = vim.fn.stdpath("config"),
     },
   },
   -- lazy can generate helptags from the headings in markdown readme files,

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ return {
         -- "zipPlugin",
       },
       -- custom_config_dir exists to work around circumstances
-      -- in which your config folder is -- not in the normal location,
+      -- in which your config folder is not in the normal location,
       -- and thus is unloaded when performance.rtp.reset = true
       -- such as when loaded from the nix store
       custom_config_dir = vim.fn.stdpath("config"),

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ return {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
-    -- you may include a list of local paths to also check.
+    -- you may include a list of local paths to also check. e.g. { '~/projects1', '~/projects1' }
     extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ return {
     rtp = {
       reset = true, -- reset the runtime path to $VIMRUNTIME and your config directory
       ---@type string[]
-      paths = {}, -- add any custom paths here that you want to includes in the rtp
+      paths = {}, -- add any custom paths here that you want to include in the rtp
       ---@type string[] list any plugins you want to disable here
       disabled_plugins = {
         -- "gzip",

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ return {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
-    -- you may include a list of local paths to also check. e.g. { '~/projects1', '~/projects1' }
+    -- you may include a list of local paths to also check. e.g. { '~/projects1', '~/projects2' }
     extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
@@ -438,9 +438,10 @@ return {
         -- "tutor",
         -- "zipPlugin",
       },
-      -- to work around circumstances in which your config folder is
-      -- not in the normal location when performance.rtp.reset = true
-      -- such as when loading your config folder from the nix store.
+      -- custom_config_dir exists to work around circumstances
+      -- in which your config folder is -- not in the normal location,
+      -- and thus is unloaded when performance.rtp.reset = true
+      -- such as when loaded from the nix store
       custom_config_dir = vim.fn.stdpath("config"),
     },
   },

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ return {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
-    -- you may also include a list of paths to also check.
+    -- you may include a list of local paths to also check.
     extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -219,15 +219,13 @@ function M.setup(opts)
   table.insert(M.options.install.colorscheme, "habamax")
 
   -- normalize path options
-  local normalized_extra_dev_paths = {}
   if type(M.options.dev.extra_paths) == "table" then
+    local normalized_extra_dev_paths = {}
     for k, path in ipairs(M.options.dev.extra_paths) do
       table.insert(normalized_extra_dev_paths, k, Util.norm(path))
     end
-  else
-    normalized_extra_dev_paths = M.options.dev.extra_paths
+    M.options.dev.extra_paths = normalized_extra_dev_paths
   end
-  M.options.dev.extra_paths = normalized_extra_dev_paths
   M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)
   M.options.root = Util.norm(M.options.root)
   M.options.dev.path = Util.norm(M.options.dev.path)

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -32,6 +32,7 @@ M.defaults = {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
+    -- you may include a list of local paths to also check.
     extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -32,7 +32,7 @@ M.defaults = {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
-    -- you may include a list of local paths to also check. e.g. { '~/projects1', '~/projects1' }
+    -- you may include a list of local paths to also check. e.g. { '~/projects1', '~/projects2' }
     extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
@@ -148,9 +148,10 @@ M.defaults = {
         -- "tutor",
         -- "zipPlugin",
       },
-      -- to work around circumstances in which your config folder is
-      -- not in the normal location when performance.rtp.reset = true
-      -- such as when loading your config folder from the nix store.
+      -- custom_config_dir exists to work around circumstances
+      -- in which your config folder is -- not in the normal location,
+      -- and thus is unloaded when performance.rtp.reset = true
+      -- such as when loaded from the nix store
       custom_config_dir = vim.fn.stdpath("config"),
     },
   },

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -134,7 +134,7 @@ M.defaults = {
     rtp = {
       reset = true, -- reset the runtime path to $VIMRUNTIME and your config directory
       ---@type string[]
-      paths = {}, -- add any custom paths here that you want to includes in the rtp
+      paths = {}, -- add any custom paths here that you want to include in the rtp
       ---@type string[] list any plugins you want to disable here
       disabled_plugins = {
         -- "gzip",
@@ -146,6 +146,10 @@ M.defaults = {
         -- "tutor",
         -- "zipPlugin",
       },
+      -- to work around circumstances in which your config folder is
+      -- not in the normal location when performance.rtp.reset = true
+      -- such as when loading your config folder from the nix store.
+      custom_config_dir = vim.fn.stdpath("config"),
     },
   },
   -- lazy can generate helptags from the headings in markdown readme files,
@@ -227,12 +231,12 @@ function M.setup(opts)
   M.me = Util.norm(vim.fn.fnamemodify(M.me, ":p:h:h:h:h"))
   if M.options.performance.rtp.reset then
     vim.opt.rtp = {
-      vim.fn.stdpath("config"),
+      vim.options.performance.rtp.custom_config_dir,
       vim.fn.stdpath("data") .. "/site",
       M.me,
       vim.env.VIMRUNTIME,
       vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim",
-      vim.fn.stdpath("config") .. "/after",
+      vim.options.performance.rtp.custom_config_dir .. "/after",
     }
   end
   for _, path in ipairs(M.options.performance.rtp.paths) do

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -239,6 +239,7 @@ function M.setup(opts)
 
   M.me = debug.getinfo(1, "S").source:sub(2)
   M.me = Util.norm(vim.fn.fnamemodify(M.me, ":p:h:h:h:h"))
+  M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)
   if M.options.performance.rtp.reset then
     vim.opt.rtp = {
       M.options.performance.rtp.custom_config_dir,

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -226,7 +226,6 @@ function M.setup(opts)
     end
     M.options.dev.extra_paths = normalized_extra_dev_paths
   end
-  M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)
   M.options.root = Util.norm(M.options.root)
   M.options.dev.path = Util.norm(M.options.dev.path)
   M.options.lockfile = Util.norm(M.options.lockfile)

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -218,10 +218,15 @@ function M.setup(opts)
   end
   table.insert(M.options.install.colorscheme, "habamax")
 
+  -- normalize path options
+  local normalized_extra_dev_paths
+  for k, path in ipairs(M.options.dev.extra_paths) do
+    table.insert(normalized_extra_dev_paths, k, Util.norm(path))
+  end
+  M.options.dev.extra_paths = normalized_extra_dev_paths
+  M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)
   M.options.root = Util.norm(M.options.root)
   M.options.dev.path = Util.norm(M.options.dev.path)
-  M.options.dev.extra_paths = Util.norm(M.options.dev.extra_paths)
-  M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)
   M.options.lockfile = Util.norm(M.options.lockfile)
   M.options.readme.root = Util.norm(M.options.readme.root)
 

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -231,12 +231,12 @@ function M.setup(opts)
   M.me = Util.norm(vim.fn.fnamemodify(M.me, ":p:h:h:h:h"))
   if M.options.performance.rtp.reset then
     vim.opt.rtp = {
-      vim.options.performance.rtp.custom_config_dir,
+      M.options.performance.rtp.custom_config_dir,
       vim.fn.stdpath("data") .. "/site",
       M.me,
       vim.env.VIMRUNTIME,
       vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim",
-      vim.options.performance.rtp.custom_config_dir .. "/after",
+      M.options.performance.rtp.custom_config_dir .. "/after",
     }
   end
   for _, path in ipairs(M.options.performance.rtp.paths) do

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -149,7 +149,7 @@ M.defaults = {
         -- "zipPlugin",
       },
       -- custom_config_dir exists to work around circumstances
-      -- in which your config folder is -- not in the normal location,
+      -- in which your config folder is not in the normal location,
       -- and thus is unloaded when performance.rtp.reset = true
       -- such as when loaded from the nix store
       custom_config_dir = vim.fn.stdpath("config"),

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -220,8 +220,10 @@ function M.setup(opts)
 
   -- normalize path options
   local normalized_extra_dev_paths
-  for k, path in ipairs(M.options.dev.extra_paths) do
-    table.insert(normalized_extra_dev_paths, k, Util.norm(path))
+  if type(M.options.dev.extra_paths) == "table" then
+    for k, path in ipairs(M.options.dev.extra_paths) do
+      table.insert(normalized_extra_dev_paths, k, Util.norm(path))
+    end
   end
   M.options.dev.extra_paths = normalized_extra_dev_paths
   M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -224,6 +224,8 @@ function M.setup(opts)
     for k, path in ipairs(M.options.dev.extra_paths) do
       table.insert(normalized_extra_dev_paths, k, Util.norm(path))
     end
+  else
+    normalized_extra_dev_paths = M.options.dev.extra_paths
   end
   M.options.dev.extra_paths = normalized_extra_dev_paths
   M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -32,6 +32,7 @@ M.defaults = {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
+    extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
     fallback = false, -- Fallback to git when local plugin doesn't exist

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -219,7 +219,7 @@ function M.setup(opts)
   table.insert(M.options.install.colorscheme, "habamax")
 
   -- normalize path options
-  local normalized_extra_dev_paths
+  local normalized_extra_dev_paths = {}
   if type(M.options.dev.extra_paths) == "table" then
     for k, path in ipairs(M.options.dev.extra_paths) do
       table.insert(normalized_extra_dev_paths, k, Util.norm(path))

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -32,7 +32,7 @@ M.defaults = {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
-    -- you may include a list of local paths to also check.
+    -- you may include a list of local paths to also check. e.g. { '~/projects1', '~/projects1' }
     extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
@@ -220,6 +220,8 @@ function M.setup(opts)
 
   M.options.root = Util.norm(M.options.root)
   M.options.dev.path = Util.norm(M.options.dev.path)
+  M.options.dev.extra_paths = Util.norm(M.options.dev.extra_paths)
+  M.options.performance.rtp.custom_config_dir = Util.norm(M.options.performance.rtp.custom_config_dir)
   M.options.lockfile = Util.norm(M.options.lockfile)
   M.options.readme.root = Util.norm(M.options.readme.root)
 

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -106,11 +106,31 @@ function Spec:add(plugin, results)
   end
 
   -- dev plugins
+  local devPath = nil
+
+  -- check dev.path, and if not check dev.extra_paths
+  -- if not found, devPath will remain nil
+  if plugin.dev then
+    if vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1 then
+      devPath = Config.options.dev.path .. "/" .. plugin.name
+    elseif Config.options.dev.extra_paths
+        and type(Config.options.dev.extra_paths) == 'table'
+      then
+      for _, path in ipairs(Config.options.dev.extra_paths) do
+        if vim.fn.isdirectory(path .. "/" .. plugin.name) == 1 then
+          path = devPath
+          break
+        end
+      end
+    end
+  end
+
+  -- if dev, add dev path as plugin dir, otherwise use root
   if
     plugin.dev
-    and (not Config.options.dev.fallback or vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1)
+    and (not Config.options.dev.fallback or devPath)
   then
-    dir = Config.options.dev.path .. "/" .. plugin.name
+    dir = devPath
   elseif plugin.dev == false then
     -- explicitely select the default path
     dir = Config.options.root .. "/" .. plugin.name

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -118,7 +118,7 @@ function Spec:add(plugin, results)
       then
       for _, path in ipairs(Config.options.dev.extra_paths) do
         if vim.fn.isdirectory(path .. "/" .. plugin.name) == 1 then
-          path = devPath
+          devPath = path
           break
         end
       end

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -118,7 +118,7 @@ function Spec:add(plugin, results)
       then
       for _, path in ipairs(Config.options.dev.extra_paths) do
         if vim.fn.isdirectory(path .. "/" .. plugin.name) == 1 then
-          devPath = path
+          devPath = path .. "/" .. plugin.name
           break
         end
       end


### PR DESCRIPTION
-- TL;DR Edit:
Forgive me that this was done in so many commits, I am not an experienced coder, just a passionate one.
I would recommend just checking the Files changed tab....
This commit adds 2 options.

Part of why this is so many commits is that I added the 2 options separately.
The other part of why it is so many commits is that I messed up doing path normalization.

The 2 options are:
Config.options.performance.rtp.custom_config_dir
Config.options.dev.extra_paths

Both are necessary for smooth integration with config folders loaded via the nix store.
If you do not use these options, nothing happens, and if you use them, they do not break existing options.

When using nix, it is possible to load your entire config directory via the nix store.
However, lazy then removes it.

While the lua vim.fn.stdpath is technically overwriteable, the vim version is not.
Plus, this would cause issues for any plugin that tries to write to that directory.
Therefore, just overriding vim.fn.stdpath('config') for the duration of lazy setup is not a satisfying option.

It is possible to completely stop the resetting of the runtimepath via option performance.rtp.reset but this comes with performance drawbacks (and it makes lua print(vim.o.runtimepath) scroll off the screen its so long because it adds everything individually like twice over....)

The solution is to allow you to optionally specify a custom config directory.

This is the only thing stopping me from having the same configuration file that uses lazy.nvim for loading on both nix setups, and non-nix setups.

In addition, doing this uses the dev.path option, making it unavailable for use, and it requires all plugins be put in the start section. Therefore, I have added dev.extra_paths option so that I can add both the start and opt directories.