### PR TITLE
feat(ui): add option to disable lazy.nvim installer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ return {
     -- Track each new require in the Lazy profiling tab
     require = false,
   },
+  -- Show the lazy.nvim installer interface
+  show_ui = true,
 }
 ```
 

--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -567,6 +567,8 @@ CONFIGURATION                              *lazy.nvim-lazy.nvim-configuration*
         -- Track each new require in the Lazy profiling tab
         require = false,
       },
+      -- Show the lazy.nvim installer interface
+      show_ui = true,
     }
 <
 

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -174,6 +174,7 @@ M.defaults = {
     -- Track each new require in the Lazy profiling tab
     require = false,
   },
+	show_ui = true,
   debug = false,
 }
 

--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -73,7 +73,8 @@ function M.install_missing()
         end
       end
       Cache.reset()
-      require("lazy.manage").install({ wait = true, lockfile = true, clear = false })
+
+      require("lazy.manage").install({ show = Config.options.show_ui, wait = true, lockfile = true, clear = false })
       -- remove any installed plugins from indexed, so cache will index again
       for _, p in pairs(Config.plugins) do
         if p._.installed then


### PR DESCRIPTION
This commit adds a option to disable lazy.nvim ui when it start setting up plugins.

Solves #1253