### PR TITLE
Added performance.rtp.custom_config_dir and dev.extra_paths for nixcompatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ return {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
+    -- you may include a list of local paths to also check. e.g. { '~/projects1', '~/projects2' }
+    extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
     fallback = false, -- Fallback to git when local plugin doesn't exist
@@ -424,7 +426,7 @@ return {
     rtp = {
       reset = true, -- reset the runtime path to $VIMRUNTIME and your config directory
       ---@type string[]
-      paths = {}, -- add any custom paths here that you want to includes in the rtp
+      paths = {}, -- add any custom paths here that you want to include in the rtp
       ---@type string[] list any plugins you want to disable here
       disabled_plugins = {
         -- "gzip",
@@ -436,6 +438,11 @@ return {
         -- "tutor",
         -- "zipPlugin",
       },
+      -- custom_config_dir exists to work around circumstances
+      -- in which your config folder is not in the normal location,
+      -- and thus is unloaded when performance.rtp.reset = true
+      -- such as when loaded from the nix store
+      custom_config_dir = vim.fn.stdpath("config"),
     },
   },
   -- lazy can generate helptags from the headings in markdown readme files,

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -106,11 +106,31 @@ function Spec:add(plugin, results)
   end
 
   -- dev plugins
+  local devPath = nil
+
+  -- check dev.path, and if not check dev.extra_paths
+  -- if not found, devPath will remain nil
+  if plugin.dev then
+    if vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1 then
+      devPath = Config.options.dev.path .. "/" .. plugin.name
+    elseif Config.options.dev.extra_paths
+        and type(Config.options.dev.extra_paths) == 'table'
+      then
+      for _, path in ipairs(Config.options.dev.extra_paths) do
+        if vim.fn.isdirectory(path .. "/" .. plugin.name) == 1 then
+          devPath = path .. "/" .. plugin.name
+          break
+        end
+      end
+    end
+  end
+
+  -- if dev, add dev path as plugin dir, otherwise use root
   if
     plugin.dev
-    and (not Config.options.dev.fallback or vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1)
+    and (not Config.options.dev.fallback or devPath)
   then
-    dir = Config.options.dev.path .. "/" .. plugin.name
+    dir = devPath
   elseif plugin.dev == false then
     -- explicitely select the default path
     dir = Config.options.root .. "/" .. plugin.name


### PR DESCRIPTION
Changes to be committed:
modified:   README.md
modified:   lua/lazy/core/config.lua
modified:   lua/lazy/core/plugin.lua

This commit adds 2 options.

The 2 options are:
Config.options.performance.rtp.custom_config_dir
Config.options.dev.extra_paths

Both are necessary for smooth integration with config folders loaded via the nix store.
If you do not use these options, nothing happens, and if you use them, they do not break existing options.

When using nix, it is possible to load your entire config directory via the nix store.
However, lazy then removes it.

While the lua vim.fn.stdpath is technically overwriteable, the vim version is not.
Plus, this would cause issues for any plugin that tries to write to that directory.
Therefore, just overriding vim.fn.stdpath('config') for the duration of lazy setup is not a satisfying option.

It is possible to completely stop the resetting of the runtimepath via option performance.rtp.reset but this comes with performance drawbacks (and it makes lua print(vim.o.runtimepath) scroll off the screen its so long because it adds everything individually like twice over....)

The solution is to allow you to optionally specify a custom config directory.

This is the only thing stopping me from having the same configuration file that uses lazy.nvim for loading on both nix setups, and non-nix setups.

In addition, doing this uses the dev.path option, making it unavailable for use, and it requires all plugins be put in the start section. Therefore, I have added dev.extra_paths option so that I can add both the start and opt directories, and still allow my users to use the dev.path option.