### PR TITLE
Added 2 options for nix compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ return {
   dev = {
     -- directory where you store your local plugin projects
     path = "~/projects",
+    ---@type string[] | nil you may include a list of local paths to also check
+    extra_paths = nil,
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
     fallback = false, -- Fallback to git when local plugin doesn't exist
@@ -424,7 +426,7 @@ return {
     rtp = {
       reset = true, -- reset the runtime path to $VIMRUNTIME and your config directory
       ---@type string[]
-      paths = {}, -- add any custom paths here that you want to includes in the rtp
+      paths = {}, -- add any custom paths here that you want to append to the rtp
       ---@type string[] list any plugins you want to disable here
       disabled_plugins = {
         -- "gzip",
@@ -436,6 +438,18 @@ return {
         -- "tutor",
         -- "zipPlugin",
       },
+      -- for niche situations where lazy breaks oddly built configurations
+      -- such as those that can be produced via nix.
+      ---@type fun(DEFAULT: string[], ME: string, VIMRUNTIME: string, NVIM_LIB: string): string[]
+      override_base_rtp = function(DEFAULT, ME, VIMRUNTIME, NVIM_LIB) return DEFAULT end
+      -- DEFAULT = {
+      --   vim.fn.stdpath("config"),
+      --   vim.fn.stdpath("data") .. "/site",
+      --   ME,
+      --   VIMRUNTIME,
+      --   NVIM_LIB,
+      --   vim.fn.stdpath("config") .. "/after",
+      -- }
     },
   },
   -- lazy can generate helptags from the headings in markdown readme files,

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -106,11 +106,31 @@ function Spec:add(plugin, results)
   end
 
   -- dev plugins
+  local devPath = nil
+
+  -- check dev.path, and if not check dev.extra_paths
+  -- if not found, devPath will remain nil
+  if plugin.dev then
+    if vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1 then
+      devPath = Config.options.dev.path .. "/" .. plugin.name
+    elseif Config.options.dev.extra_paths
+        and type(Config.options.dev.extra_paths) == 'table'
+      then
+      for _, path in ipairs(Config.options.dev.extra_paths) do
+        if vim.fn.isdirectory(path .. "/" .. plugin.name) == 1 then
+          devPath = path .. "/" .. plugin.name
+          break
+        end
+      end
+    end
+  end
+
+  -- if dev, add dev path as plugin dir, otherwise use root
   if
     plugin.dev
-    and (not Config.options.dev.fallback or vim.fn.isdirectory(Config.options.dev.path .. "/" .. plugin.name) == 1)
+    and (not Config.options.dev.fallback or devPath)
   then
-    dir = Config.options.dev.path .. "/" .. plugin.name
+    dir = devPath
   elseif plugin.dev == false then
     -- explicitely select the default path
     dir = Config.options.root .. "/" .. plugin.name

--- a/lua/lazy/core/util.lua
+++ b/lua/lazy/core/util.lua
@@ -64,6 +64,19 @@ function M.norm(path)
   return path:sub(-1) == "/" and path:sub(1, -2) or path
 end
 
+---@return table | nil
+function M.norm_list(list)
+  if M.is_list(list) then
+    local normalized_paths = {}
+    for k, path in ipairs(list) do
+      table.insert(normalized_paths, k, M.norm(path))
+    end
+    return normalized_paths
+  else
+    return nil
+  end
+end
+
 ---@param opts? {level?: number}
 function M.pretty_trace(opts)
   opts = opts or {}


### PR DESCRIPTION
Fully backwards compatible with minimal runtime impact 
options are: 
dev.extra_paths and performance.rtp.override_base_rtp

--- performance.rtp.override_base_rtp

On nix, various items are added to the runtime path of neovim.

When using nix, it is possible to load your entire config directory via the nix store.
However, lazy then removes it. It also removes your treesitter grammars.

I found a way to add them back. But now they were being sourced at the incorrect times. The builtin grammars were overriding the treesitter grammars I added via performance.rtp.paths and throwing errors and breaking highlighting. It also meant my after directory was not being included properly.

While the lua vim.fn.stdpath is technically overwriteable, the vim version is not.
Plus, this would cause issues for any plugin that tries to write to that directory.
Therefore, just overriding vim.fn.stdpath('config') for the duration of lazy setup is not a satisfying option.

Likewise there was no good option for treesitter grammars.

It is possible to completely stop the resetting of the runtimepath via option performance.rtp.reset but this comes with performance drawbacks (and it makes lua print(vim.o.runtimepath) scroll off the screen its so long because it adds everything individually like twice over....)

The solution is to allow you to optionally override the base runtime path. I have hopefully done it in a way that makes it useable while not impacting performance (its a passthrough function)

This is the only thing stopping me from having the same configuration file that uses lazy.nvim for loading on both nix setups, and non-nix setups.

--- dev.extra_paths

In addition to that, I was adding the plugins themselves via a different method that would take advantage of lazy's lazy loading.

I used the dev.path option for telling lazy about the nix downloaded plugins, making it available for use. I then add the names of the plugins as patterns automatically.

However it makes the option unavailable for normal use and it requires all plugins be put in the start section. Therefore, I have added dev.extra_paths option so that I can add both the start and opt directories.

I tried simply iterating through the lazy specs myself and adding in the dir argument for each, but that increases startup time even more than performance.rtp.reset = false does, and also is very challenging due to the fact that the import statement can require directories that were previously remote. This ended up being the best way to do it that I could find.

For context, I made a format for importing neovim directories into nix.
https://github.com/BirdeeHub/nixCats-nvim
You can check out the 5.0.0 branch if you would like to for the proposed nix+lazy compatibility options I am adding in context. It is in lua/nixCatsUtils/lazyCat.lua
https://github.com/BirdeeHub/nixCats-nvim/tree/nixCats-5.0.0
People would like to have the same folder for all scenarios nix or not, and lazy is the only package manager that takes over the rtp in this way.

here is a template that downloads and runs kickstart.nix using my fork. I think its awesome and a lot of people want lazy in nix.
https://github.com/BirdeeHub/nixCats-nvim/blob/nixCats-5.0.0/nix/templates/kickstart-nvim/init.lua