### PR TITLE
Update plugin.lua

### DIFF
--- a/lua/lazy/manage/task/plugin.lua
+++ b/lua/lazy/manage/task/plugin.lua
@@ -79,7 +79,7 @@ M.docs = {
     return not plugin._.dirty
   end,
   run = function(self)
-    local docs = self.plugin.dir .. "/doc/"
+    local docs = self.plugin.dir .. "/doc"
     if Util.file_exists(docs) then
       self.output = vim.api.nvim_cmd({ cmd = "helptags", args = { docs } }, { output = true })
     end


### PR DESCRIPTION
Not sure if this can be reproduced elsewhere that on my machine,
but 
the `vim.api.nvim_cmd({ cmd = "helptags", args = { docs } }, { output = true })` instruction seems to fail if there is a trailing slash

I get a bunch of 
```
    ● mason-lspconfig.nvim 0.3ms  nvim-lspconfig
        ...hare/nvim/lazy/lazy.nvim/lua/lazy/manage/task/plugin.lua:84: Vim:E150: Not a directory: /Users/pg/.local/share/nvim/lazy/mason-lspconfig.nvim/doc/
```

errors when updating lazy plugins.
