### PR TITLE
Clone only the last commit when installing lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ if not vim.loop.fs_stat(lazypath) then
   vim.fn.system({
     "git",
     "clone",
+    "--depth=1",
     "--filter=blob:none",
     "https://github.com/folke/lazy.nvim.git",
     "--branch=stable", -- latest stable release


### PR DESCRIPTION
Update `README.md` to add `--depth=1` when cloning `lazy.nvim` repo.