### PR TITLE
Nix compatibility option: performance.rtp.override_base_rtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ return {
       -- for niche situations where you need to inject earlier in the load cycle
       -- such as adding things that must be sourced before VIMRUNTIME
       ---@type fun(DEFAULT: string[], ME: string): string[]
-      override_base_rtp = function(DEFAULT, ME) return DEFAULT end
+      override_base_rtp = function(DEFAULT, ME) return DEFAULT end,
       -- DEFAULT = {
       --   vim.fn.stdpath("config"),
       --   vim.fn.stdpath("data") .. "/site",

--- a/README.md
+++ b/README.md
@@ -438,14 +438,14 @@ return {
       },
       -- for niche situations where you need to inject earlier in the load cycle
       -- such as adding things that must be sourced before VIMRUNTIME
-      ---@type fun(DEFAULT: string[], ME: string, VIMRUNTIME: string, NVIM_LIB: string): string[]
-      override_base_rtp = function(DEFAULT, ME, VIMRUNTIME, NVIM_LIB) return DEFAULT end
+      ---@type fun(DEFAULT: string[], ME: string): string[]
+      override_base_rtp = function(DEFAULT, ME) return DEFAULT end
       -- DEFAULT = {
       --   vim.fn.stdpath("config"),
       --   vim.fn.stdpath("data") .. "/site",
       --   ME,
-      --   VIMRUNTIME,
-      --   NVIM_LIB,
+      --   vim.env.VIMRUNTIME,
+      --   vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim",
       --   vim.fn.stdpath("config") .. "/after",
       -- }
     },

--- a/README.md
+++ b/README.md
@@ -436,6 +436,18 @@ return {
         -- "tutor",
         -- "zipPlugin",
       },
+      -- for niche situations where you need to inject earlier in the load cycle
+      -- such as adding things that must be sourced before VIMRUNTIME
+      ---@type fun(DEFAULT: string[], ME: string, VIMRUNTIME: string, NVIM_LIB: string): string[]
+      override_base_rtp = function(DEFAULT, ME, VIMRUNTIME, NVIM_LIB) return DEFAULT end
+      -- DEFAULT = {
+      --   vim.fn.stdpath("config"),
+      --   vim.fn.stdpath("data") .. "/site",
+      --   ME,
+      --   VIMRUNTIME,
+      --   NVIM_LIB,
+      --   vim.fn.stdpath("config") .. "/after",
+      -- }
     },
   },
   -- lazy can generate helptags from the headings in markdown readme files,

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -148,14 +148,14 @@ M.defaults = {
       },
       -- for niche situations where you need to inject earlier in the load cycle
       -- such as adding things that must be sourced before VIMRUNTIME
-      ---@type fun(DEFAULT: string[], ME: string, VIMRUNTIME: string, NVIM_LIB: string): string[]
-      override_base_rtp = function(DEFAULT, ME, VIMRUNTIME, NVIM_LIB) return DEFAULT end
+      ---@type fun(DEFAULT: string[], ME: string): string[]
+      override_base_rtp = function(DEFAULT, ME) return DEFAULT end
       -- DEFAULT = {
       --   vim.fn.stdpath("config"),
       --   vim.fn.stdpath("data") .. "/site",
       --   ME,
-      --   VIMRUNTIME,
-      --   NVIM_LIB,
+      --   vim.env.VIMRUNTIME,
+      --   vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim",
       --   vim.fn.stdpath("config") .. "/after",
       -- }
     },
@@ -238,16 +238,15 @@ function M.setup(opts)
   M.me = debug.getinfo(1, "S").source:sub(2)
   M.me = Util.norm(vim.fn.fnamemodify(M.me, ":p:h:h:h:h"))
   if M.options.performance.rtp.reset then
-    local NVIM_LIB = vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim"
     local base_rtp = {
       vim.fn.stdpath("config"),
       vim.fn.stdpath("data") .. "/site",
       M.me,
       vim.env.VIMRUNTIME,
-      NVIM_LIB,
+      vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim",
       vim.fn.stdpath("config") .. "/after",
     }
-    vim.opt.rtp = M.options.performance.rtp.override_base_rtp(base_rtp, M.me, vim.env.VIMRUNTIME, NVIM_LIB)
+    vim.opt.rtp = M.options.performance.rtp.override_base_rtp(base_rtp, M.me)
   end
   for _, path in ipairs(M.options.performance.rtp.paths) do
     vim.opt.rtp:append(path)

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -149,7 +149,7 @@ M.defaults = {
       -- for niche situations where you need to inject earlier in the load cycle
       -- such as adding things that must be sourced before VIMRUNTIME
       ---@type fun(DEFAULT: string[], ME: string): string[]
-      override_base_rtp = function(DEFAULT, ME) return DEFAULT end
+      override_base_rtp = function(DEFAULT, ME) return DEFAULT end,
       -- DEFAULT = {
       --   vim.fn.stdpath("config"),
       --   vim.fn.stdpath("data") .. "/site",

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -146,6 +146,18 @@ M.defaults = {
         -- "tutor",
         -- "zipPlugin",
       },
+      -- for niche situations where you need to inject earlier in the load cycle
+      -- such as adding things that must be sourced before VIMRUNTIME
+      ---@type fun(DEFAULT: string[], ME: string, VIMRUNTIME: string, NVIM_LIB: string): string[]
+      override_base_rtp = function(DEFAULT, ME, VIMRUNTIME, NVIM_LIB) return DEFAULT end
+      -- DEFAULT = {
+      --   vim.fn.stdpath("config"),
+      --   vim.fn.stdpath("data") .. "/site",
+      --   ME,
+      --   VIMRUNTIME,
+      --   NVIM_LIB,
+      --   vim.fn.stdpath("config") .. "/after",
+      -- }
     },
   },
   -- lazy can generate helptags from the headings in markdown readme files,
@@ -226,14 +238,16 @@ function M.setup(opts)
   M.me = debug.getinfo(1, "S").source:sub(2)
   M.me = Util.norm(vim.fn.fnamemodify(M.me, ":p:h:h:h:h"))
   if M.options.performance.rtp.reset then
-    vim.opt.rtp = {
+    local NVIM_LIB = vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim"
+    local base_rtp = {
       vim.fn.stdpath("config"),
       vim.fn.stdpath("data") .. "/site",
       M.me,
       vim.env.VIMRUNTIME,
-      vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib/nvim",
+      NVIM_LIB,
       vim.fn.stdpath("config") .. "/after",
     }
+    vim.opt.rtp = M.options.performance.rtp.override_base_rtp(base_rtp, M.me, vim.env.VIMRUNTIME, NVIM_LIB)
   end
   for _, path in ipairs(M.options.performance.rtp.paths) do
     vim.opt.rtp:append(path)


### PR DESCRIPTION
additional option is performance.rtp.override_base_rtp
only 4 lines of code, changes nothing if not set. Simple passthrough function.

--- performance.rtp.override_base_rtp

On nix, various items are added to the runtime path of neovim.

When using nix, it is possible to load your entire config directory via the nix store.
However, lazy then removes it. It also removes your treesitter grammars.

I found a way to add them back. But now they were being sourced at the incorrect times. The builtin grammars were overriding the treesitter grammars I added via performance.rtp.paths and throwing errors and breaking highlighting. It also meant my after directory was not being included properly.

While the lua vim.fn.stdpath is technically overwriteable, the vim version is not.
Plus, this would cause issues for any plugin that tries to write to that directory.
Therefore, just overriding vim.fn.stdpath('config') for the duration of lazy setup is not a satisfying option.

Likewise there was no good option for treesitter grammars.

It is possible to completely stop the resetting of the runtimepath via option performance.rtp.reset but this comes with performance drawbacks (and it makes lua print(vim.o.runtimepath) scroll off the screen its so long because it adds everything individually like twice over....)

The solution is to allow you to optionally override the base runtime path. I have hopefully done it in a way that makes it useable while not impacting performance (its a passthrough function)

This is the only thing stopping me from having the same configuration file that uses lazy.nvim for loading on both nix setups, and non-nix setups.


For context, I made a format for importing neovim directories into nix.
You can check out the 5.0.0 branch if you would like to for the proposed nix+lazy compatibility options I am adding in context. It is in lua/nixCatsUtils/lazyCat.lua
https://github.com/BirdeeHub/nixCats-nvim/tree/nixCats-5.0.0
People would like to have the same folder for all scenarios nix or not, and lazy is the only package manager that takes over the rtp in this way.

here is a template that downloads and runs kickstart.nvim using my fork. I think its awesome and a lot of people want lazy in nix.
https://github.com/BirdeeHub/nixCats-nvim/blob/nixCats-5.0.0/nix/templates/kickstart-nvim/init.lua