### PR TITLE
fix(loader): respect empty colorscheme (#713)

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -210,7 +210,9 @@ function M.setup(opts)
   if type(M.options.spec) == "string" then
     M.options.spec = { import = M.options.spec }
   end
-  table.insert(M.options.install.colorscheme, "habamax")
+  if #M.options.install.colorscheme > 0 then
+      table.insert(M.options.install.colorscheme, "habamax")
+  end
 
   M.options.root = Util.norm(M.options.root)
   M.options.dev.path = Util.norm(M.options.dev.path)


### PR DESCRIPTION
This gives the option to not override default colorscheme during plugin installation by using the configuration:

```
{
    install = {
        colorscheme = {},
    },
}
```

If the user specifies a scheme or keeps the default, we will fall back to 'habamax' as before.

Note: the simple fix is to just remove the line and expect users to explicitly use `['theme1', 'habamax']` if needed but I tried to stay closer to the current semantics.