### PR TITLE
Fix false warning when checking plugins configured with 'submodules' key

### DIFF
--- a/lua/lazy/health.lua
+++ b/lua/lazy/health.lua
@@ -131,6 +131,7 @@ M.valid = {
   "opts",
   "pin",
   "priority",
+  "submodules",
   "tag",
   "url",
   "version",


### PR DESCRIPTION
Fixes #1174.