### PR TITLE
fix(git): comment sign detection in get_config function

### DIFF
--- a/lua/lazy/manage/git.lua
+++ b/lua/lazy/manage/git.lua
@@ -217,7 +217,7 @@ function M.get_config(repo)
       current_section = section:gsub('%s+"', "."):gsub('"+%s*$', "")
     else
       -- Ignore comments and blank lines
-      if not line:match("^%s*#") and line:match("%S") then
+      if not line:match("^%s*[#;]") and line:match("%S") then
         local key, value = line:match("^%s*(%S+)%s*=%s*(.+)%s*$")
         ret[current_section .. "." .. key] = value
       end


### PR DESCRIPTION
- Modify the condition in the get_config function to correctly ignore comments and blank lines.
- Update the regular expression to exclude lines starting with '#' or ';'.
- This change ensures that only valid key-value pairs are added to the configuration table.