### PR TITLE
docs: example specs encourage type safety with ---@type LazySpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ When `[2]` is `nil`, then the real mapping has to be created by the `config()` f
 
 ```lua
 -- Example for neo-tree.nvim
+---@type LazySpec
 {
   "nvim-neo-tree/neo-tree.nvim",
     keys = {
@@ -196,6 +197,7 @@ version of plugins that support Semver.
 <!-- spec:start -->
 
 ```lua
+---@type LazySpec
 return {
   -- the colorscheme should be available when starting Neovim
   {
@@ -683,6 +685,7 @@ require("lazy").setup("plugins")
 - `~/.config/nvim/lua/plugins.lua` or `~/.config/nvim/lua/plugins/init.lua` **_(this file is optional)_**
 
 ```lua
+---@type LazySpec
 return {
   "folke/neodev.nvim",
   "folke/which-key.nvim",


### PR DESCRIPTION
This should help users catch some typos in their configuration.

<details><summary>Example of using an incorrect type</summary>
<p>

<img width="808" alt="image" src="https://github.com/folke/lazy.nvim/assets/300791/d21917da-3840-4200-8b02-54979d457835">


</p>
</details> 

It's also possible to offer completion for the available keys. This feature should be great for new users as there are quite a few options.

<details><summary>Example of completion</summary>
<p>

<img width="948" alt="image" src="https://github.com/folke/lazy.nvim/assets/300791/1ae02b6d-2bc1-4253-8272-ddf821addd7c">


</p>
</details> 

---

This PR also opens the door for type checking the example configuration as part of the CI build. I have seen some tools that are able to run checks on markdown code blocks but have never tried one myself, though.

Please let me know if there's some further work I could help with. I might be able to contribute further changes later on 👍🏻 