### PR TITLE
fix: update to new treesitter capture groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ To uninstall **lazy.nvim**, you need to remove the following files and directori
 | **LazyCommitScope**   | **_Italic_**               | conventional commit scope                           |
 | **LazyCommitType**    | **_Title_**                | conventional commit type                            |
 | **LazyDimmed**        | **_Conceal_**              | property                                            |
-| **LazyDir**           | **_@text.reference_**      | directory                                           |
+| **LazyDir**           | **_@markup.link_**         | directory                                           |
 | **LazyH1**            | **_IncSearch_**            | home button                                         |
 | **LazyH2**            | **_Bold_**                 | titles                                              |
 | **LazyLocal**         | **_Constant_**             |                                                     |
@@ -805,14 +805,14 @@ To uninstall **lazy.nvim**, you need to remove the following files and directori
 | **LazyReasonImport**  | **_Identifier_**           |                                                     |
 | **LazyReasonKeys**    | **_Statement_**            |                                                     |
 | **LazyReasonPlugin**  | **_Special_**              |                                                     |
-| **LazyReasonRequire** | **_@parameter_**           |                                                     |
+| **LazyReasonRequire** | **_@variable.parameter_**  |                                                     |
 | **LazyReasonRuntime** | **_@macro_**               |                                                     |
 | **LazyReasonSource**  | **_Character_**            |                                                     |
-| **LazyReasonStart**   | **_@field_**               |                                                     |
+| **LazyReasonStart**   | **_@variable.member_**     |                                                     |
 | **LazySpecial**       | **_@punctuation.special_** |                                                     |
 | **LazyTaskError**     | **_ErrorMsg_**             | task errors                                         |
 | **LazyTaskOutput**    | **_MsgArea_**              | task output                                         |
-| **LazyUrl**           | **_@text.reference_**      | url                                                 |
+| **LazyUrl**           | **_@markup.link_**         | url                                                 |
 | **LazyValue**         | **_@string_**              | value of a property                                 |
 
 <!-- colors:end -->

--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -923,7 +923,7 @@ Click to see all highlight groups ~
 
   LazyDimmed          Conceal                  property
 
-  LazyDir             _@text.reference_        directory
+  LazyDir             _@markup.link_           directory
 
   LazyH1              IncSearch                homebutton
 
@@ -954,13 +954,13 @@ Click to see all highlight groups ~
 
   LazyReasonPlugin    Special                  
 
-  LazyReasonRequire   _@parameter_             
+  LazyReasonRequire   _@variable.parameter_             
 
   LazyReasonRuntime   _@macro_                 
 
   LazyReasonSource    Character                
 
-  LazyReasonStart     _@field_                 
+  LazyReasonStart     _@variable.member_                 
 
   LazySpecial         _@punctuation.special_   
 
@@ -968,7 +968,7 @@ Click to see all highlight groups ~
 
   LazyTaskOutput      MsgArea                  task output
 
-  LazyUrl             _@text.reference_        url
+  LazyUrl             _@markup.link_           url
 
   LazyValue           _@string_                valueof a property
   ---------------------------------------------------------------------------------

--- a/lua/lazy/view/colors.lua
+++ b/lua/lazy/view/colors.lua
@@ -21,18 +21,18 @@ M.colors = {
   ReasonPlugin = "Special",
   ReasonEvent = "Constant",
   ReasonKeys = "Statement",
-  ReasonStart = "@field",
+  ReasonStart = "@variable.member",
   ReasonSource = "Character",
   ReasonFt = "Character",
   ReasonCmd = "Operator",
   ReasonImport = "Identifier",
-  ReasonRequire = "@parameter",
+  ReasonRequire = "@variable.parameter",
   Button = "CursorLine",
   ButtonActive = "Visual",
   TaskOutput = "MsgArea", -- task output
   TaskError = "ErrorMsg", -- task errors
-  Dir = "@text.reference", -- directory
-  Url = "@text.reference", -- url
+  Dir = "@markup.link", -- directory
+  Url = "@markup.link", -- url
 }
 
 M.did_setup = false

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -476,7 +476,7 @@ function M:log(task)
         ["#%d+"] = "LazyCommitIssue",
         ["^%S+:"] = dimmed and "Bold" or "LazyCommitType",
         ["^%S+(%(.*%))!?:"] = "LazyCommitScope",
-        ["`.-`"] = "@text.literal.markdown_inline",
+        ["`.-`"] = "@markup.raw.markdown_inline",
         ["%*.-%*"] = "Italic",
         ["%*%*.-%*%*"] = "Bold",
       })
@@ -582,7 +582,7 @@ function M:profile()
     self:append("Based on the actual CPU time of the Neovim process till "):append("UIEnter", "LazySpecial")
     self:append("."):nl()
     self:append("This is more accurate than ")
-    self:append("`nvim --startuptime`", "@text.literal.markdown_inline")
+    self:append("`nvim --startuptime`", "@markup.raw.markdown_inline")
     self:append(".")
   else
     self:append("An accurate startuptime based on the actual CPU time of the Neovim process is not available."):nl()


### PR DESCRIPTION
Syncs the Tree-sitter highlights to use the new upstream capture groups, as defined by https://github.com/nvim-treesitter/nvim-treesitter/pull/5831