### PR TITLE
feat(health): Warn about unused keys when normalizing a LazySpec[] 

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -353,7 +353,7 @@ function Spec:normalize(spec, results)
     else
       self:add({ spec }, results)
     end
-  elseif #spec > 1 or Util.is_list(spec) then
+  elseif #spec > 1 or Util.is_list(spec) or type(spec[1]) == "table" then
     ---@cast spec LazySpec[]
     local ignored_keys_exist = false
     for k, s in pairs(spec) do

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -366,10 +366,10 @@ function Spec:normalize(spec, results)
     end
     if ignored_keys_exist then
       -- HACK: Uses hashing order to insert the warning after integer keys, but before the rest of LazySpec's string keys
-      spec["WARNING:"] = "-- Ignored keys below! --"
+      spec[" WARNING "] = "-- Ignored keys below! --"
       self:warn(
-        "This list of specs has extraneous keys - "
-          .. "they do not belong to any plugins, so they are currently ignored by lazy.nvim:\n"
+        "This list of plugin specs has extraneous keys - "
+          .. "they do not belong to any specs, so they are currently ignored by lazy.nvim:\n"
           .. vim.inspect(spec, {
             depth = 2,
             process = function(item, path)

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -370,7 +370,8 @@ function Spec:normalize(spec, results)
       -- HACK: Uses hashing order to insert the warning after integer keys, but before the rest of LazySpec's string keys
       spec["WARNING:"] = "-- Ignored keys below! --"
       self:warn(
-        "This list of specs has extraneous keys - these will not be processed by lazy.nvim as they do not belong to any plugins: "
+        "This list of specs has extraneous keys - "
+          .. "these will not be processed by lazy.nvim as they do not belong to any plugins:\n"
           .. vim.inspect(spec, { depth = 2, process = processor })
           .. "\n"
       )

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -341,6 +341,12 @@ function Spec:report(level)
   return count
 end
 
+local remove_internal_keys = function(item, path)
+  if path[#path] == "_" then
+    return nil
+  end
+  return item
+end
 ---@param spec LazySpec|LazySpecImport
 ---@param results? string[]
 function Spec:normalize(spec, results)
@@ -371,8 +377,8 @@ function Spec:normalize(spec, results)
       spec["WARNING:"] = "-- Ignored keys below! --"
       self:warn(
         "This list of specs has extraneous keys - "
-          .. "these will not be processed by lazy.nvim as they do not belong to any plugins:\n"
-          .. vim.inspect(spec, { depth = 2, process = processor })
+          .. "they do not belong to any plugins, so they are currently unused by lazy.nvim:\n"
+          .. vim.inspect(spec, { depth = 2, process = remove_internal_keys })
           .. "\n"
       )
     end

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -369,7 +369,7 @@ function Spec:normalize(spec, results)
       spec["WARNING:"] = "-- Ignored keys below! --"
       self:warn(
         "This list of specs has extraneous keys - "
-          .. "they do not belong to any plugins, so they are currently unused by lazy.nvim:\n"
+          .. "they do not belong to any plugins, so they are currently ignored by lazy.nvim:\n"
           .. vim.inspect(spec, {
             depth = 2,
             process = function(item, path)


### PR DESCRIPTION
Occasionally, users may put the configuration keys for a plugin into a `LazySpec[]`, rather than a specific `LazySpec`. Alternatively, they may add a new `LazySpec|string` into an existing `LazySpec` for a plugin. This leads to some configuration keys being silently ignored by `lazy.nvim` after normalization, which can be confusing to new `lazy.nvim` users.

This PR adds a health check to `Spec:normalize()` which will warn about the misplaced keys.

Example of a `LazySpec[]` that will trigger this:

```lua
return {
  {
    'lewis6991/gitsigns.nvim',
    event = { 'BufNewFile', 'BufReadPre' },
    dependencies = { 'nvim-lua/plenary.nvim' },
    opts = {
      signs = {
        add = { hl = 'GitSignsAdd', text = '│', numhl = 'GitSignsAddNr', linehl = 'GitSignsAddLn' },
        change = { hl = 'GitSignsChange', text = '│', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn' },
        delete = { hl = 'GitSignsDelete', text = '_', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn' },
        topdelete = { hl = 'GitSignsDelete', text = '‾', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn' },
        changedelete = { hl = 'GitSignsChange', text = '~', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn' },
      },
      numhl = true, -- Toggle with `:Gitsigns toggle_numhl`
      watch_gitdir = {
        interval = 1000,
        follow_files = true,
      },
    },
    'pwntester/octo.nvim',
  },
}
```

The resulting healthcheck warning with this PR (`:Lazy health`):
![image](https://github.com/folke/lazy.nvim/assets/43484729/a1cc3020-243f-4594-a03d-8f5592846186)

This is how a longer warning looks like:
![image](https://github.com/folke/lazy.nvim/assets/43484729/a47052b6-4806-4348-a871-768ebf62417c)

# Concerns:

- On my machine, this PR can slow down spec processsing by a few ms when warning about big tables (I assume due to `vim.inspect`). For reference, spec processing takes ~5ms for me without this warning.
- How should I word and format the warning message? The current method is admittedly hacky, but I like how it looks.