### PR TITLE
feat(render): merge keybindings in UI

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -621,10 +621,25 @@ function M:handlers(plugin, types)
   types = type(types) == "string" and { types } or types
   types = types and types or vim.tbl_keys(Handler.types)
   for _, t in ipairs(types) do
-    for id, value in pairs(plugin._.handlers[t] or {}) do
-      value = t == "keys" and Keys.to_string(value) or id
-      self:reason({ [t] = value })
-      self:append(" ")
+    items = plugin._.handlers[t] or {}
+    if t == "keys" then
+      local last_key_val = nil
+      for id, value in vim.spairs(items) do
+        value = Keys.to_string(value) or id
+        local value_pat = vim.pesc(value)
+        if last_key_val and string.find(value_pat, "^" .. last_key_val) then
+            -- matches previous, shorter prefix - pass
+        else
+          self:reason({ [t] = value })
+          self:append(" ")
+          last_key_val = value_pat
+        end
+      end
+    else
+      for _, value in pairs(items) do
+        self:reason({ [t] = value })
+        self:append(" ")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR updates the keybindings view in the "hints" section in lazy home.
Activation keys for plugins are now iterated in sorted order (by keys) and
common prefixes, if present, are shown instead of all the individual
keybindings.

Given a config like this:

```
return {
    {
        'rcarriga/nvim-notify',
        lazy = true,
        keys = {
            { "<leader>N",  desc = "+notifications" },
            { "<leader>Ny", "<Cmd>Notifications<CR>", desc = "history (plain)" },
            { "<leader>Nd", function() require("notify").dismiss() end, desc = "dismiss" },
            { "<leader>Np", function() require("notify").pending() end, desc = "show pending" },
        },
    },
}
```

The UI entry in the *Not Loaded* plugins now looks like this:

```
   ○ nvim-notify  <leader>N
```

instead of previously:

```
   ○ nvim-notify  <leader>Nd  <leader>Np  <leader>N  <leader>Ny
```

As a side-effect, this ensures that, even if no "common prefix" exists, keys
are always shown in sorted order.


## Additional remarks

### Compound keybindings

I assume that the current implementation fails when "Ctrl"-based keybindings
are mixed with anything that has "C" as a prefix, for example. I'm not sure
about the exact notation of Ctrl-/Alt-keybindings in nvim because I never use
them, but a quick test with this setup:

```lua
        keys = {
            { "<leader>C",  desc = "+notifications" },
            { "<leader>Cy", "<Cmd>Notifications<CR>", desc = "history (plain)" },
            { "<leader>C-d", function() require("notify").dismiss() end, desc = "dismiss" },
            { "<leader>Cp", function() require("notify").pending() end, desc = "show pending" },
        },
```

shortens the whole group to `<leader>C` in the UI, where it should probably
show `<leader>C <leader>C-d` instead. In a similar fashion, I assume that a
scenario like this fails as well:

```lua
        keys = {
            -- Plain "C" with plain "-"
            { "<leader>C-",  desc = "+notifications" },
            { "<leader>C-y", "<Cmd>Notifications<CR>", desc = "history (plain)" },
            { "<leader>C-d", function() require("notify").dismiss() end, desc = "dismiss" },
            { "<leader>C-p", function() require("notify").pending() end, desc = "show pending" },
        },
```

although I'm unsure whether this is a realistic scenario to consider here. Is
there something like an iterator over individual/compound keys in the raw data?
Or do I have to check whether `C-?` is part of a compound binding myself? If
so, do you know of any other compound bindings I should be aware of?


### which-key integration

Users of which-key will probably *not* benefit from this change. That is
because keybinding groups must be registered in which-key directly (so the
"group"-prefix is picked up correctly), so lazy doesn't know about them. Since
keybindings can only be performed once, we cannot just "copy" the which-key
group assignment into lazy just for the UI.

I've opened a [PR for which-key][1] that solves this inconvenience, in case
you're interested.

[1]: https://github.com/folke/which-key.nvim/pull/557
