### PR TITLE
fix(types): fix incorrect LuaLS types

### DIFF
--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -69,7 +69,7 @@
 ---@field event? string[]|string|LazyEventSpec[]|fun(self:LazyPlugin, event:string[]):string[]
 ---@field cmd? string[]|string|fun(self:LazyPlugin, cmd:string[]):string[]
 ---@field ft? string[]|string|fun(self:LazyPlugin, ft:string[]):string[]
----@field keys? string|string[]|LazyKeysSpec[]|fun(self:LazyPlugin, keys:string[]):(string|LazyKeys)[]
+---@field keys? string|string[]|LazyKeysSpec[]|fun(self:LazyPlugin, keys:string[]):((string|LazyKeys)[])
 ---@field module? false
 
 ---@class LazyPluginSpec: LazyPluginBase,LazyPluginSpecHandlers,LazyPluginHooks,LazyPluginRef


### PR DESCRIPTION
Without the added parentheses, the type were resolved to

```
(field) keys: (
  |string
  |LazyKeysSpec[]
  |fun(self: LazyPlugin, keys: string[]):string
  |LazyKeys[]
  |string[]
)?
```

With the paren, it now correctly resolves to
```
(field) keys: (
  |string
  |LazyKeysSpec[]
  |fun(_: LazyPlugin, keys: string[]):(string|LazyKeys)[]
  |string[]
)?
```