### PR TITLE
fix(ui): Add "bot" to dimmed commands list

### DIFF
--- a/lua/lazy/view/config.lua
+++ b/lua/lazy/view/config.lua
@@ -24,7 +24,7 @@ function M.get_commands()
   return ret
 end
 
-M.dimmed_commits = { "build", "ci", "chore", "doc", "style", "test" }
+M.dimmed_commits = { "bot", "build", "ci", "chore", "doc", "style", "test" }
 
 M.keys = {
   hover = "K",


### PR DESCRIPTION
nvim-treesitter has added a bot to automate updating parsers. This feels similar to the other commands that are dimmed.