### PR TITLE
Update README.md: (Fix install instructions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can add the following Lua code to your `init.lua` to bootstrap **lazy.nvim**
 
 ```lua
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.uv.fs_stat(lazypath) then
+if not vim.loop.fs_stat(lazypath) then
   vim.fn.system({
     "git",
     "clone",


### PR DESCRIPTION
When copying the new instructions (using `uv` instead of `loop`) into my config I receive the following error:
```
Error detected while processing /home/damiano/.config/nvim/init.lua:
E5113: Error while calling lua chunk: /home/damiano/.config/nvim/init.lua:19: attempt to index field 'uv' (a nil value)
stack traceback:
        /home/damiano/.config/nvim/init.lua:19: in main chunk
Press ENTER or type command to continue
```