### PR TITLE
Fix README Usage table

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ Any operation can be started from the UI, with a sub command or an API function:
 <!-- commands:start -->
 
 | Command | Lua | Description |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | `:Lazy build {plugins}` | `require("lazy").build(opts)` | Rebuild a plugin |
 | `:Lazy check [plugins]` | `require("lazy").check(opts?)` | Check for updates and show the log (git fetch) |
 | `:Lazy clean [plugins]` | `require("lazy").clean(opts?)` | Clean plugins that are no longer needed |


### PR DESCRIPTION
Currently it has an extra `| --- |`, so it fails to display correctly. (It was added in [this commit](https://github.com/folke/lazy.nvim/commit/a6b74f30d5aab79a40d932f449c0aa5d4a0c6934#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R520))