### PR TITLE
fix: attempt to index vim.uv on <0.10 on windows

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -413,7 +413,7 @@ CONFIGURATION                              *lazy.nvim-lazy.nvim-configuration*
       spec = nil, ---@type LazySpec
       lockfile = vim.fn.stdpath("config") .. "/lazy-lock.json", -- lockfile generated after running update.
       ---@type number? limit the maximum amount of concurrent tasks
-      concurrency = jit.os:find("Windows") and (vim.uv.available_parallelism() * 2) or nil,
+      concurrency = jit.os:find("Windows") and ((vim.uv or vim.loop).available_parallelism() * 2) or nil,
       git = {
         -- defaults for the `Lazy log` command
         -- log = { "--since=3 days ago" }, -- show commits from the last 3 days

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -18,7 +18,7 @@ M.defaults = {
   spec = nil, ---@type LazySpec
   lockfile = vim.fn.stdpath("config") .. "/lazy-lock.json", -- lockfile generated after running update.
   ---@type number? limit the maximum amount of concurrent tasks
-  concurrency = jit.os:find("Windows") and (vim.uv.available_parallelism() * 2) or nil,
+  concurrency = jit.os:find("Windows") and ((vim.uv or vim.loop).available_parallelism() * 2) or nil,
   git = {
     -- defaults for the `Lazy log` command
     -- log = { "--since=3 days ago" }, -- show commits from the last 3 days


### PR DESCRIPTION
Seemed to have missed a bit with the migration to `vim.uv`. Ran into this error after just updating to v10.20.3 on Neovim v0.9.5 on Windows.