### PR TITLE
feat(ui): toggle to show plugin URLs on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,11 @@ return {
         "‒",
       },
     },
+    urls = {
+      enabled = false, -- show URLs on home page by default
+      front = "(",
+      back = ")",
+    },
     -- leave nil, to automatically select a browser depending on your OS.
     -- If you want to use a specific browser, you can define it here
     browser = nil, ---@type string?
@@ -525,6 +530,7 @@ Any operation can be started from the UI, with a sub command or an API function:
 | `:Lazy debug` | `require("lazy").debug()` | Show debug information |
 | `:Lazy health` | `require("lazy").health()` | Run `:checkhealth lazy` |
 | `:Lazy help` | `require("lazy").help()` | Toggle this help page |
+| `:Lazy locations` | `require("lazy").locations()` | Toggle plugin URLs in plugin list |
 | `:Lazy home` | `require("lazy").home()` | Go back to plugin list |
 | `:Lazy install [plugins]` | `require("lazy").install(opts?)` | Install missing plugins |
 | `:Lazy load {plugins}` | `require("lazy").load(opts)` | Load a plugin that has not been loaded yet. Similar to `:packadd`. Like `:Lazy load foo.nvim`. Use `:Lazy! load` to skip `cond` checks. |

--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -634,6 +634,9 @@ function:
   :Lazy health              require("lazy").health()         Run :checkhealth lazy
 
   :Lazy help                require("lazy").help()           Toggle this help page
+  
+  :Lazy locations           require("lazy").locations()      Toggle plugin URLs in
+                                                             plugin list
 
   :Lazy home                require("lazy").home()           Go back to plugin list
 

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -79,6 +79,11 @@ M.defaults = {
         "‒",
       },
     },
+    urls = {
+      enabled = false, -- show URLs on home page by default
+      front = "",
+      back = "",
+    },
     -- leave nil, to automatically select a browser depending on your OS.
     -- If you want to use a specific browser, you can define it here
     browser = nil, ---@type string?

--- a/lua/lazy/view/commands.lua
+++ b/lua/lazy/view/commands.lua
@@ -43,6 +43,9 @@ M.commands = {
   help = function()
     View.show("help")
   end,
+  locations = function()
+    View.urls()
+  end,
   debug = function()
     View.show("debug")
   end,

--- a/lua/lazy/view/config.lua
+++ b/lua/lazy/view/config.lua
@@ -120,30 +120,37 @@ M.commands = {
     key = "D",
     toggle = true,
   },
+  locations = {
+    button = false,
+    desc = "Toggle plugin locations (URL)",
+    id = 11,
+    key = "T",
+    toggle = true,
+  },
   help = {
     button = true,
     desc = "Toggle this help page",
-    id = 11,
+    id = 12,
     key = "?",
     toggle = true,
   },
   clear = {
     desc = "Clear finished tasks",
-    id = 12,
+    id = 13,
   },
   load = {
     desc = "Load a plugin that has not been loaded yet. Similar to `:packadd`. Like `:Lazy load foo.nvim`. Use `:Lazy! load` to skip `cond` checks.",
-    id = 13,
+    id = 14,
     plugins = true,
     plugins_required = true,
   },
   health = {
     desc = "Run `:checkhealth lazy`",
-    id = 14,
+    id = 15,
   },
   build = {
     desc = "Rebuild a plugin",
-    id = 15,
+    id = 16,
     plugins = true,
     plugins_required = true,
     key_plugin = "gb",
@@ -152,7 +159,7 @@ M.commands = {
     desc = "Reload a plugin (experimental!!)",
     plugins = true,
     plugins_required = true,
-    id = 16,
+    id = 17,
   },
 }
 

--- a/lua/lazy/view/init.lua
+++ b/lua/lazy/view/init.lua
@@ -8,9 +8,11 @@ local ViewConfig = require("lazy.view.config")
 
 ---@class LazyViewState
 ---@field mode string
+---@field urls boolean
 ---@field plugin? {name:string, kind?: LazyPluginKind}
 local default_state = {
   mode = "home",
+  urls = Config.options.ui.urls.enabled,
   profile = {
     threshold = 0,
     sort_time_taken = false,
@@ -27,6 +29,16 @@ M.view = nil
 
 function M.visible()
   return M.view and M.view.win and vim.api.nvim_win_is_valid(M.view.win)
+end
+
+function M.urls()
+  if Config.headless() then
+    return
+  end
+
+  M.view = M.visible() and M.view or M.create()
+  M.view.state.urls = not M.view.state.urls
+  M.view:update()
 end
 
 ---@param mode? string

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -424,6 +424,15 @@ function M:plugin(plugin)
     end
   end
   self:diagnostics(plugin)
+  if plugin.url and self.view.state.urls and self.view.state.mode == "home" and not self.view:is_selected(plugin) then
+    self:append(
+      (plugin._.loaded and " " or "")
+        .. Config.options.ui.urls.front
+        .. (plugin.url:gsub("%.git$", ""))
+        .. Config.options.ui.urls.back,
+      "LazyComment"
+    )
+  end
   self:nl()
 
   if self.view:is_selected(plugin) then

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -427,9 +427,9 @@ function M:plugin(plugin)
   if plugin.url and self.view.state.urls and self.view.state.mode == "home" and not self.view:is_selected(plugin) then
     self:append(
       (plugin._.loaded and " " or "")
-        .. Config.options.ui.urls.front
+        .. (Config.options.ui.urls.front or "(")
         .. (plugin.url:gsub("%.git$", ""))
-        .. Config.options.ui.urls.back,
+        .. (Config.options.ui.urls.back or ")"),
       "LazyComment"
     )
   end


### PR DESCRIPTION
## Problem

I like using the entire summary (home) page of lazy.nvim as an easy copy/paste list of all my plugins, but I wanted each of the plugins to have their Github links right next to them as well. This would make finding your way to a specific plugin's repo a bit easier with all the links in the summary being there and copyable/clickable, and it's just a nice thing to have visually if you copy the whole list.

## Proposal

Create a field `urls` that is toggled with the `T` key to show each plugin's Github url inline under the plugin list. The default state is off obviously to not clutter the screen if you don't want it, and the look is modified with the following additions to the config defaults under `ui`:

```lua
urls = {
  enabled = false, -- show URLs on home page by default
  front = "(",
  back = ")",
},
```

## Before

<img width="882" alt="Untitled-1" src="https://github.com/folke/lazy.nvim/assets/39519792/a7a16753-ef68-4e67-aa19-476e5522d34a">

## After

![styles](https://github.com/folke/lazy.nvim/assets/39519792/c76100ef-2d9e-4807-8884-821227799353)
<img width="882" alt="Untitled-2" src="https://github.com/folke/lazy.nvim/assets/39519792/08572042-1df9-41a5-a997-5e6e6bab0f1f">

The URL at the end of the line is hidden when clicking into the details of a plugin in the list, since it's visible there next to "url:", and plugins that are loaded locally or whatever that don't have have a `url` attribute remain unchanged.