### PR TITLE
fix: strings in lua reload

### DIFF
--- a/lua/lazy/view/commands.lua
+++ b/lua/lazy/view/commands.lua
@@ -56,6 +56,9 @@ M.commands = {
   end,
   reload = function(opts)
     for _, plugin in pairs(opts.plugins) do
+      if type(plugin) == "string" then
+        plugin = Config.plugins[plugin]
+      end
       Util.warn("Reloading **" .. plugin.name .. "**")
       require("lazy.core.loader").reload(plugin)
     end


### PR DESCRIPTION
opts.plugin can be a list of strings, but currently it would error on not being able to contact the name field

This allows providing a list of strings