### PR TITLE
load spec from different folder

### DIFF
--- a/lua/lazy/core/util.lua
+++ b/lua/lazy/core/util.lua
@@ -260,7 +260,12 @@ end
 function M.lsmod(modname, fn)
   local root = M.find_root(modname)
   if not root then
-    return
+      local Config = require("lazy.core.config")
+      if Config.options.moduledir  then
+      root = Config.options.moduledir  .. modname
+  else
+      return
+  end
   end
 
   if vim.uv.fs_stat(root .. ".lua") then


### PR DESCRIPTION
I know it probably won't be included . 
This adds moduledir option to load specs from different folder.

Made this change to resolve: 

https://github.com/folke/lazy.nvim/issues/1440

also needed to prepend it to rtp.