### PR TITLE
fix(render): disable underline for diagnostics

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -84,7 +84,7 @@ function M:update()
       diag.lnum = diag.row - 1
       return diag
     end, self._diagnostics),
-    { signs = false, virtual_text = true }
+    { signs = false, virtual_text = true, underline = false }
   )
 end
 


### PR DESCRIPTION
Problem: On current Nvim nightlies, a regression in a
`vim.highlight.range()` refactor makes underlines for diagnostics at end
of line extend into the next line, leading to visual artifacts in the
update view:

<img width="449" alt="Screenshot 2024-05-26 at 13 04 46" src="https://github.com/neovim/neovim/assets/2361214/a44520a7-120d-4ff2-bd7f-5a9570afb676">

(see https://github.com/neovim/neovim/pull/28986)

Solution: Suppress underlines for diagnostics, as they are not wanted
anyway.
