### PR TITLE
Set vim.opt.rtp type to vim.Option

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -237,6 +237,7 @@ function M.setup(opts)
   M.me = debug.getinfo(1, "S").source:sub(2)
   M.me = Util.norm(vim.fn.fnamemodify(M.me, ":p:h:h:h:h"))
   if M.options.performance.rtp.reset then
+    ---@type vim.Option
     vim.opt.rtp = {
       vim.fn.stdpath("config"),
       vim.fn.stdpath("data") .. "/site",

--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -476,6 +476,7 @@ function M.add_to_rtp(plugin)
     table.insert(rtp, idx_after or (#rtp + 1), after)
   end
 
+  ---@type vim.Option
   vim.opt.rtp = rtp
 end
 

--- a/tests/core/util_spec.lua
+++ b/tests/core/util_spec.lua
@@ -5,6 +5,7 @@ local Util = require("lazy.util")
 describe("util", function()
   local rtp = vim.opt.rtp:get()
   before_each(function()
+    ---@type vim.Option
     vim.opt.rtp = rtp
     for k, v in pairs(package.loaded) do
       if k:find("^foobar") then


### PR DESCRIPTION
## Details

There is an issue in the `neodev` repo that mentions this: [#193](https://github.com/folke/neodev.nvim/issues/193)

I think the problem comes from a combination of 2 things:

1. As mentioned in the [Reddit post](https://www.reddit.com/r/neovim/comments/1cvrilk/diagnosticwarning_after_upgrade_to_neovim_010/): `Nvim never had Lua type annotations for vim.opt`.
2. Setting `vim.opt.rtp` anywhere in the config will cause Lua-LS to infer the type for `vim.opt.rtp`. While users are unlikely to do this it does happen in `lazy.nvim`, in places shown in this PR.

## Aside

There are some longer term plans to remove `vim.opt` in general: https://github.com/neovim/neovim/issues/20107.

In the meantime setting the `type` annotation seems like a good enough hack, while it's the suggested setup in the README.

Totally understand if you don't want to keep this around, a diagnostic warning isn't a big deal. Or if you have a better way to handle this through something like `lazydev.nvim`.

Thanks for all your awesome contributions!

## Testing

I currently get the `Undefined field prepend` warning through my LSP:

![with-warning](https://github.com/folke/lazy.nvim/assets/52591095/c8a4e7a6-029c-4e7e-ae40-6be7bd13d9cc)

No longer happens after this change, `vim.opt.rtp` is recognized as a `vim.Option`:

![no-warning](https://github.com/folke/lazy.nvim/assets/52591095/0906e1de-58df-4968-8015-aadbc459f616)