### PR TITLE
feat: configurable default pinning of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ return {
   defaults = {
     lazy = false, -- should plugins be lazy-loaded?
     version = nil,
+    pin = false,
     -- default `cond` you can use to globally disable a lot of plugins
     -- when running inside vscode for example
     cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil

--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -404,6 +404,7 @@ CONFIGURATION                              *lazy.nvim-lazy.nvim-configuration*
       defaults = {
         lazy = false, -- should plugins be lazy-loaded?
         version = nil,
+        pin = false,
         -- default `cond` you can use to globally disable a lot of plugins
         -- when running inside vscode for example
         cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -9,6 +9,7 @@ M.defaults = {
   defaults = {
     lazy = false, -- should plugins be lazy-loaded?
     version = nil,
+    pin = false,
     -- default `cond` you can use to globally disable a lot of plugins
     -- when running inside vscode for example
     cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -515,6 +515,9 @@ function M.update_state()
         or plugin.cmd
       plugin.lazy = lazy and true or false
     end
+    if plugin.pin == nil then
+      plugin.pin = Config.options.defaults.pin
+    end
     if plugin.dir:find(Config.options.root, 1, true) == 1 then
       plugin._.installed = installed[plugin.name] ~= nil
       installed[plugin.name] = nil


### PR DESCRIPTION
Simple addition, but allows plugins be pinned by default by the user. I disabled this in the default config, as I believe this should be explicitly enabled.

Usage:
```lua
require("lazy").setup("plugin", { defaults = { pin = true } })
```

My personal use case is I keep my configs under version control, including my lockfile. Having plugins stick to that lockfile gives me a reproducible and stable config, at least in terms of plugins. When I wish to update, I can set the value to false, test, and commit.
This is as well important in a NixOS environment, where the config may likely be readonly, thus lazy.nvim fails when it eagerly tries updating the lockfile.

Pinning of plugins has already been used in a few Neovim distributions such as Astrovim, allegedly. I cannot certify this as I do not use a distribution.

Let me know if any additional information is needed. I have already tested this on my own config.