### PR TITLE
fix: don't check updates for local plugins

### DIFF
--- a/lua/lazy/manage/checker.lua
+++ b/lua/lazy/manage/checker.lua
@@ -35,7 +35,7 @@ end
 function M.fast_check(opts)
   opts = opts or {}
   for _, plugin in pairs(Config.plugins) do
-    if not plugin.pin and not plugin.dev and plugin._.installed then
+    if plugin._.installed and not (plugin.pin or plugin._.is_local) then
       plugin._.updates = nil
       local info = Git.info(plugin.dir)
       local ok, target = pcall(Git.get_target, plugin)

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -9,7 +9,7 @@ local M = {}
 M.log = {
   ---@param opts {updated?:boolean, check?: boolean}
   skip = function(plugin, opts)
-    if opts.check and plugin.pin then
+    if opts.check and (plugin.pin or plugin._.is_local) then
       return true
     end
     if opts.updated and not (plugin._.updated and plugin._.updated.from ~= plugin._.updated.to) then


### PR DESCRIPTION
Extends #1384 to cover all local plugins, not just dev ones. Also adds a skip condition for local plugins to the `git.log` task - without this, a local plugin that is on a different branch to that specified in the spec always shows as needing updates.