### PR TITLE
tweak: use default colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ return {
     -- install missing plugins on startup. This doesn't increase startup time.
     missing = true,
     -- try to load one of these colorschemes when starting an installation during startup
-    colorscheme = { "habamax" },
+    colorscheme = { "default" },
   },
   ui = {
     -- a number <1 is a percentage., >1 is a fixed size

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -41,8 +41,7 @@ M.defaults = {
   install = {
     -- install missing plugins on startup. This doesn't increase startup time.
     missing = true,
-    -- try to load one of these colorschemes when starting an installation during startup
-    colorscheme = { "habamax" },
+    colorscheme = { "default" },
   },
   ui = {
     -- a number <1 is a percentage., >1 is a fixed size
@@ -218,7 +217,7 @@ function M.setup(opts)
   if type(M.options.spec) == "string" then
     M.options.spec = { import = M.options.spec }
   end
-  table.insert(M.options.install.colorscheme, "habamax")
+  table.insert(M.options.install.colorscheme, "default")
 
   -- root
   M.options.root = Util.norm(M.options.root)


### PR DESCRIPTION
Set Lazy's theme to `default` instead of `habamax` since the default colorscheme has been revamped and is likely going to be better maintained into the future.

Closes #1413
Related https://github.com/LazyVim/starter/pull/72