### PR TITLE
fix(plugin): Make the `local_spec` check reject similar config module names

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -403,7 +403,9 @@ function Spec:import(spec)
   ---@type string[]
   local modnames = {}
 
-  if spec.import:find(M.LOCAL_SPEC, 1, true) then
+  -- relies on `find_local_spec` to always insert a `/` before the local spec location
+  local local_spec_suffix = "/" .. M.LOCAL_SPEC
+  if spec.import == M.LOCAL_SPEC or spec.import:sub(-#local_spec_suffix) == local_spec_suffix then
     modnames = { spec.import }
   else
     Util.lsmod(spec.import, function(modname)
@@ -415,8 +417,10 @@ function Spec:import(spec)
   for _, modname in ipairs(modnames) do
     imported = imported + 1
     local name = modname
-    if modname:find(M.LOCAL_SPEC, 1, true) then
+    local is_local_spec = false
+    if modname == M.LOCAL_SPEC or modname:sub(-#local_spec_suffix) == local_spec_suffix then
       name = vim.fn.fnamemodify(modname, ":~:.")
+      is_local_spec = true
     end
     Util.track({ import = name })
     self.importing = modname
@@ -425,7 +429,7 @@ function Spec:import(spec)
     package.loaded[modname] = nil
     Util.try(function()
       local mod = nil
-      if modname:find(M.LOCAL_SPEC, 1, true) then
+      if is_local_spec then
         mod = M.local_spec(modname)
       else
         mod = require(modname)

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -405,7 +405,7 @@ function Spec:import(spec)
 
   -- relies on `find_local_spec` to always insert a `/` before the local spec location
   local local_spec_suffix = "/" .. M.LOCAL_SPEC
-  if spec.import == M.LOCAL_SPEC or spec.import:sub(-#local_spec_suffix) == local_spec_suffix then
+  if spec.import:sub(-#local_spec_suffix) == local_spec_suffix then
     modnames = { spec.import }
   else
     Util.lsmod(spec.import, function(modname)
@@ -418,7 +418,7 @@ function Spec:import(spec)
     imported = imported + 1
     local name = modname
     local is_local_spec = false
-    if modname == M.LOCAL_SPEC or modname:sub(-#local_spec_suffix) == local_spec_suffix then
+    if modname:sub(-#local_spec_suffix) == local_spec_suffix then
       name = vim.fn.fnamemodify(modname, ":~:.")
       is_local_spec = true
     end


### PR DESCRIPTION
Fixes [a bug found by a user on r/neovim](https://www.reddit.com/r/neovim/comments/1dgtyzw/lazynvim_doesnt_like_lualinenvim/) introduced by e2e10d9 where a `modname` such as `user.lazy.lualine` would match the `local_spec` check for `.lazy.lua`.

I've modified the check to account for modnames such as `user.lazy.lualine` and `plugins.lazy.lua`. Although while I was doing this, I was wondering if the spec should store a psuedo-private bool about being a local_spec or not instead? I didn't want to make the diff too big though and this seems performant enough to me so I'm just submitting this for now.