### PR TITLE
fix(config): only enable rocks if `luarocks` is installed

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -46,7 +46,7 @@ M.defaults = {
     },
   },
   rocks = {
-    enabled = true,
+    enabled = vim.fn.executable("luarocks") == 1,
     root = vim.fn.stdpath("data") .. "/lazy-rocks",
     server = "https://nvim-neorocks.github.io/rocks-binaries/",
   },


### PR DESCRIPTION
This disables rocks packages by default if `luarocks` is not installed on the user's system