### PR TITLE
fix(docs): Minor clarification.

### DIFF
--- a/README.vim.md
+++ b/README.vim.md
@@ -713,38 +713,38 @@ with a lazy extension in `lazy`.
 
 | Highlight Group | Default Group | Description |
 | --- | --- | --- |
-| **LazyButton** | _**CursorLine**_ |  |
-| **LazyButtonActive** | _**Visual**_ |  |
-| **LazyComment** | _**Comment**_ |  |
-| **LazyCommit** | _**@variable.builtin**_ | commit ref |
-| **LazyCommitIssue** | _**Number**_ |  |
-| **LazyCommitScope** | _**Italic**_ | conventional commit scope |
-| **LazyCommitType** | _**Title**_ | conventional commit type |
-| **LazyDimmed** | _**Conceal**_ | property |
-| **LazyDir** | _**@markup.link**_ | directory |
-| **LazyH1** | _**IncSearch**_ | home button |
-| **LazyH2** | _**Bold**_ | titles |
-| **LazyLocal** | _**Constant**_ |  |
-| **LazyNoCond** | _**DiagnosticWarn**_ | unloaded icon for a plugin where `cond()` was false |
-| **LazyNormal** | _**NormalFloat**_ |  |
-| **LazyProgressDone** | _**Constant**_ | progress bar done |
-| **LazyProgressTodo** | _**LineNr**_ | progress bar todo |
-| **LazyProp** | _**Conceal**_ | property |
-| **LazyReasonCmd** | _**Operator**_ |  |
-| **LazyReasonEvent** | _**Constant**_ |  |
-| **LazyReasonFt** | _**Character**_ |  |
-| **LazyReasonImport** | _**Identifier**_ |  |
-| **LazyReasonKeys** | _**Statement**_ |  |
-| **LazyReasonPlugin** | _**Special**_ |  |
-| **LazyReasonRequire** | _**@variable.parameter**_ |  |
-| **LazyReasonRuntime** | _**@macro**_ |  |
-| **LazyReasonSource** | _**Character**_ |  |
-| **LazyReasonStart** | _**@variable.member**_ |  |
-| **LazySpecial** | _**@punctuation.special**_ |  |
-| **LazyTaskError** | _**ErrorMsg**_ | task errors |
-| **LazyTaskOutput** | _**MsgArea**_ | task output |
-| **LazyUrl** | _**@markup.link**_ | url |
-| **LazyValue** | _**@string**_ | value of a property |
+| **LazyButton** | ***CursorLine*** |  |
+| **LazyButtonActive** | ***Visual*** |  |
+| **LazyComment** | ***Comment*** |  |
+| **LazyCommit** | ***@variable.builtin*** | commit ref |
+| **LazyCommitIssue** | ***Number*** |  |
+| **LazyCommitScope** | ***Italic*** | conventional commit scope |
+| **LazyCommitType** | ***Title*** | conventional commit type |
+| **LazyDimmed** | ***Conceal*** | property |
+| **LazyDir** | ***@markup.link*** | directory |
+| **LazyH1** | ***IncSearch*** | home button |
+| **LazyH2** | ***Bold*** | titles |
+| **LazyLocal** | ***Constant*** |  |
+| **LazyNoCond** | ***DiagnosticWarn*** | unloaded icon for a plugin where `cond()` was false |
+| **LazyNormal** | ***NormalFloat*** |  |
+| **LazyProgressDone** | ***Constant*** | progress bar done |
+| **LazyProgressTodo** | ***LineNr*** | progress bar todo |
+| **LazyProp** | ***Conceal*** | property |
+| **LazyReasonCmd** | ***Operator*** |  |
+| **LazyReasonEvent** | ***Constant*** |  |
+| **LazyReasonFt** | ***Character*** |  |
+| **LazyReasonImport** | ***Identifier*** |  |
+| **LazyReasonKeys** | ***Statement*** |  |
+| **LazyReasonPlugin** | ***Special*** |  |
+| **LazyReasonRequire** | ***@variable.parameter*** |  |
+| **LazyReasonRuntime** | ***@macro*** |  |
+| **LazyReasonSource** | ***Character*** |  |
+| **LazyReasonStart** | ***@variable.member*** |  |
+| **LazySpecial** | ***@punctuation.special*** |  |
+| **LazyTaskError** | ***ErrorMsg*** | task errors |
+| **LazyTaskOutput** | ***MsgArea*** | task output |
+| **LazyUrl** | ***@markup.link*** | url |
+| **LazyValue** | ***@string*** | value of a property |
 
 # 🚀 Usage
 
@@ -1092,4 +1092,3 @@ local dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
 ```
 
 :::
-

--- a/README.vim.md
+++ b/README.vim.md
@@ -388,7 +388,7 @@ when doing `colorscheme foobar`.
 
 :::warning
 
-since **start** plugins can possibly change existing highlight groups,
+since **start** plugins (`lazy=false`) can possibly change existing highlight groups,
 it's important to make sure that your main **colorscheme** is loaded first.
 To ensure this you can use the `priority=1000` field. **_(see the [examples](./examples.md))_**
 
@@ -713,38 +713,38 @@ with a lazy extension in `lazy`.
 
 | Highlight Group | Default Group | Description |
 | --- | --- | --- |
-| **LazyButton** | ***CursorLine*** |  |
-| **LazyButtonActive** | ***Visual*** |  |
-| **LazyComment** | ***Comment*** |  |
-| **LazyCommit** | ***@variable.builtin*** | commit ref |
-| **LazyCommitIssue** | ***Number*** |  |
-| **LazyCommitScope** | ***Italic*** | conventional commit scope |
-| **LazyCommitType** | ***Title*** | conventional commit type |
-| **LazyDimmed** | ***Conceal*** | property |
-| **LazyDir** | ***@markup.link*** | directory |
-| **LazyH1** | ***IncSearch*** | home button |
-| **LazyH2** | ***Bold*** | titles |
-| **LazyLocal** | ***Constant*** |  |
-| **LazyNoCond** | ***DiagnosticWarn*** | unloaded icon for a plugin where `cond()` was false |
-| **LazyNormal** | ***NormalFloat*** |  |
-| **LazyProgressDone** | ***Constant*** | progress bar done |
-| **LazyProgressTodo** | ***LineNr*** | progress bar todo |
-| **LazyProp** | ***Conceal*** | property |
-| **LazyReasonCmd** | ***Operator*** |  |
-| **LazyReasonEvent** | ***Constant*** |  |
-| **LazyReasonFt** | ***Character*** |  |
-| **LazyReasonImport** | ***Identifier*** |  |
-| **LazyReasonKeys** | ***Statement*** |  |
-| **LazyReasonPlugin** | ***Special*** |  |
-| **LazyReasonRequire** | ***@variable.parameter*** |  |
-| **LazyReasonRuntime** | ***@macro*** |  |
-| **LazyReasonSource** | ***Character*** |  |
-| **LazyReasonStart** | ***@variable.member*** |  |
-| **LazySpecial** | ***@punctuation.special*** |  |
-| **LazyTaskError** | ***ErrorMsg*** | task errors |
-| **LazyTaskOutput** | ***MsgArea*** | task output |
-| **LazyUrl** | ***@markup.link*** | url |
-| **LazyValue** | ***@string*** | value of a property |
+| **LazyButton** | _**CursorLine**_ |  |
+| **LazyButtonActive** | _**Visual**_ |  |
+| **LazyComment** | _**Comment**_ |  |
+| **LazyCommit** | _**@variable.builtin**_ | commit ref |
+| **LazyCommitIssue** | _**Number**_ |  |
+| **LazyCommitScope** | _**Italic**_ | conventional commit scope |
+| **LazyCommitType** | _**Title**_ | conventional commit type |
+| **LazyDimmed** | _**Conceal**_ | property |
+| **LazyDir** | _**@markup.link**_ | directory |
+| **LazyH1** | _**IncSearch**_ | home button |
+| **LazyH2** | _**Bold**_ | titles |
+| **LazyLocal** | _**Constant**_ |  |
+| **LazyNoCond** | _**DiagnosticWarn**_ | unloaded icon for a plugin where `cond()` was false |
+| **LazyNormal** | _**NormalFloat**_ |  |
+| **LazyProgressDone** | _**Constant**_ | progress bar done |
+| **LazyProgressTodo** | _**LineNr**_ | progress bar todo |
+| **LazyProp** | _**Conceal**_ | property |
+| **LazyReasonCmd** | _**Operator**_ |  |
+| **LazyReasonEvent** | _**Constant**_ |  |
+| **LazyReasonFt** | _**Character**_ |  |
+| **LazyReasonImport** | _**Identifier**_ |  |
+| **LazyReasonKeys** | _**Statement**_ |  |
+| **LazyReasonPlugin** | _**Special**_ |  |
+| **LazyReasonRequire** | _**@variable.parameter**_ |  |
+| **LazyReasonRuntime** | _**@macro**_ |  |
+| **LazyReasonSource** | _**Character**_ |  |
+| **LazyReasonStart** | _**@variable.member**_ |  |
+| **LazySpecial** | _**@punctuation.special**_ |  |
+| **LazyTaskError** | _**ErrorMsg**_ | task errors |
+| **LazyTaskOutput** | _**MsgArea**_ | task output |
+| **LazyUrl** | _**@markup.link**_ | url |
+| **LazyValue** | _**@string**_ | value of a property |
 
 # 🚀 Usage
 
@@ -1092,3 +1092,4 @@ local dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
 ```
 
 :::
+

--- a/docs/spec/lazy_loading.md
+++ b/docs/spec/lazy_loading.md
@@ -28,7 +28,7 @@ when doing `colorscheme foobar`.
 
 :::warning
 
-since **start** plugins can possibly change existing highlight groups,
+since **start** plugins (`lazy=false`) can possibly change existing highlight groups,
 it's important to make sure that your main **colorscheme** is loaded first.
 To ensure this you can use the `priority=1000` field. **_(see the [examples](./examples.md))_**
 


### PR DESCRIPTION
This is minor but it tripped me up for a bit. I was setting all my colorschemes to lazy load without realizing that it was negating the `priority` option altogether. The statement explaining that colorschemes *can* be lazy loaded with `lazy = true` followed immediately by a note about setting the `priority` for your main colorscheme seemed to imply that the specified priority would work with lazy loaded colorschemes.

![image](https://github.com/folke/lazy.nvim/assets/874394/b8a0bc16-b977-48d0-bc63-c8de8664beab)

This PR just adds the clarification that a "start plugin" implies `lazy=false`. It's just the same clarification that is already used for the `priority` description.

![image](https://github.com/folke/lazy.nvim/assets/874394/80d69bb5-4333-49c7-a2f7-6a149dde5435)
