### PR TITLE
fix(git): local plugin fixes

### DIFF
--- a/lua/lazy/manage/checker.lua
+++ b/lua/lazy/manage/checker.lua
@@ -35,7 +35,9 @@ end
 function M.fast_check(opts)
   opts = opts or {}
   for _, plugin in pairs(Config.plugins) do
-    if not plugin.pin and not plugin.dev and plugin._.installed then
+    -- don't check local plugins here, since we mark them as needing updates
+    -- only if local is behind upstream (if the git log task gives no output)
+    if plugin._.installed and not (plugin.pin or plugin._.is_local) then
       plugin._.updates = nil
       local info = Git.info(plugin.dir)
       local ok, target = pcall(Git.get_target, plugin)

--- a/lua/lazy/manage/git.lua
+++ b/lua/lazy/manage/git.lua
@@ -116,6 +116,12 @@ end
 ---@param plugin LazyPlugin
 ---@return GitInfo?
 function M.get_target(plugin)
+  if plugin._.is_local then
+    local info = M.info(plugin.dir)
+    local branch = assert(info and info.branch or M.get_branch(plugin))
+    return { branch = branch, commit = M.get_commit(plugin.dir, branch, true) }
+  end
+
   local branch = assert(M.get_branch(plugin))
 
   if plugin.commit then
@@ -144,15 +150,6 @@ function M.get_target(plugin)
       }
     end
   end
-  ---@diagnostic disable-next-line: return-type-mismatch
-  return { branch = branch, commit = M.get_commit(plugin.dir, branch, true) }
-end
-
----@param plugin LazyPlugin
----@return GitInfo?
-function M.get_local_target(plugin)
-  local info = M.info(plugin.dir)
-  local branch = assert(info and info.branch or M.get_branch(plugin))
   return { branch = branch, commit = M.get_commit(plugin.dir, branch, true) }
 end
 

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -38,7 +38,7 @@ M.log = {
       table.insert(args, self.plugin._.updated.from .. ".." .. (self.plugin._.updated.to or "HEAD"))
     elseif opts.check then
       info = assert(Git.info(self.plugin.dir))
-      target = assert(self.plugin._.is_local and Git.get_local_target(self.plugin) or Git.get_target(self.plugin))
+      target = assert(Git.get_target(self.plugin))
       if not target.commit then
         for k, v in pairs(target) do
           error(k .. " '" .. v .. "' not found")


### PR DESCRIPTION
## Description

As I described in https://github.com/folke/lazy.nvim/pull/1512#issuecomment-2212474372, this makes it so that local plugins will only show as needing updates if the local branch is behind the upstream branch. This is done by checking the output of the `git log` command, and only setting `plugin._.updates` if the output is not empty.

This seems to solve my issue where local plugins with unpushed changes always show as needing updates, but if there's a easier/better way of doing it then please feel free to edit/close this. Or if you don't agree that the current behaviour is a bug, then that's also fine - it's not a big deal and I can easily just ignore the "updates available" notice.

I also came across a minor issue where the plugin diff view (press `d`) compares the wrong commits for local plugins, because [lua/lazy/view/init.lua](https://github.com/folke/lazy.nvim/blob/c771cf4928d1a1428ac7461658ab2916ed48adf5/lua/lazy/view/init.lua#L268) always uses `get_target`. I fixed this by moving `get_local_target` into `get_target` - I think this is simpler and more straightforward than the alternative of adding a ternary everywhere `get_target` is called.

This second bugfix is a very small change, so I've just included it here, but I'm happy to make a second PR if you'd like.

## Related Issue(s)

Related PR: #1512