### PR TITLE
FIX ISSUE #1626

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -253,9 +253,8 @@ M.mapleader = nil
 ---@type string
 M.maplocalleader = nil
 
-local headless = #vim.api.nvim_list_uis() == 0
 function M.headless()
-  return headless
+  return #vim.api.nvim_list_uis() == 0
 end
 
 ---@param opts? LazyConfig


### PR DESCRIPTION
## Description

Check whether nvim is currently headless, not whether it was headless at startup.  This fixes the UI not showing up when running Lazy commands after attaching to a headless instance.

## Related Issue(s)

- Fixes #1626
