### PR TITLE
fix(lockfile): ensure newline at EOF for lockfile

### DIFF
--- a/lua/lazy/manage/lock.lua
+++ b/lua/lazy/manage/lock.lua
@@ -42,7 +42,7 @@ function M.update()
       f:write(",\n")
     end
   end
-  f:write("\n}")
+  f:write("\n}\n")
   f:close()
 end
 


### PR DESCRIPTION
## Description

The lockfile currently does not end with a newline at EOF. Text files should [end with a newline](https://unix.stackexchange.com/a/18789). This also lets you manually edit the lockfile in vim without 'fixeol' creating a spurious change for the added newline.

This change however will create a change in users' lockfiles adding a newline upon updating, but since the lockfile would be changing anyways to update lazy.nvim itself, this is likely acceptable.

## Related Issue(s)

*none*

## Screenshots

*N/A*

