### PR TITLE
fix(health): when executing commands show "command not found" on Wind…

### DIFF
--- a/lua/lazy/health.lua
+++ b/lua/lazy/health.lua
@@ -36,7 +36,7 @@ function M.have(cmd, opts)
   local found
   for _, c in ipairs(cmd) do
     if vim.fn.executable(c) == 1 then
-      local version = vim.fn.system(c .. " " .. opts.version) or ""
+      local version = vim.fn.system([["]] .. c .. " " .. opts.version .. [["]]) or ""
       if vim.v.shell_error ~= 0 then
         opts.error(("failed to get version of {%s}\n%s"):format(c, version))
       else


### PR DESCRIPTION
…ows platform.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Add double quote in windows platform, "checkhealth lazy" shows OK. It's not PATH issue.
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
 - Fixes #1599 
## Screenshots

<!-- Add screenshots of the changes if applicable. -->
before
![before](https://github.com/user-attachments/assets/1f4272d1-787e-4533-8033-679678d52e72)

after
![after](https://github.com/user-attachments/assets/70e01a7b-ae57-4350-a425-9f6c612deeab)

