### PR TITLE
docs(commands): fix command ordering for sync

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -988,8 +988,8 @@ function:
                                                              lockfile or to a given
                                                              commit under the cursor
 
-  :Lazy sync [plugins]      require("lazy").sync(opts?)      Run install, clean and
-                                                             update
+  :Lazy sync [plugins]      require("lazy").sync(opts?)      Run clean, install, and
+                                                             update commands
 
   :Lazy update [plugins]    require("lazy").update(opts?)    Update plugins. This
                                                              will also update the


### PR DESCRIPTION
## Description

After a discussion on Slack we noticed that the description of the sync command is a bit vague. Some people, including myself, assumed `clean`/`install`/`update` referred to build steps being performed per plugin.

Another person mentioned they thought it referred to the Lazy commands, which does make more sense.
They also noticed that the order of the commands do not match the source code.

So this PR corrects the order, assuming it was meant to be ordered, and mentions that those are commands for clarity.