### PR TITLE
fix(plugins): "Vim:E150: Not a directory" on plugin update

### DIFF
--- a/lua/lazy/manage/task/plugin.lua
+++ b/lua/lazy/manage/task/plugin.lua
@@ -90,7 +90,7 @@ M.docs = {
     return not plugin._.dirty
   end,
   run = function(self)
-    local docs = self.plugin.dir .. "/doc/"
+    local docs = self.plugin.dir .. "/doc"
     if Util.file_exists(docs) then
       self:log(vim.api.nvim_cmd({ cmd = "helptags", args = { docs } }, { output = true }))
     end


### PR DESCRIPTION
## Description

On plugins update it fails with following error for any plugin.

```
~/.local/share/nvim/lazy/lazy.nvim/manage/task/plugin.lua:95: Vim:E150: Not a directory: ~/.local/share/nvim/lazy/gitsigns.nvim/doc/
```

