### PR TITLE
fix(luarocks): try to install from root manifest

### DIFF
--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -172,7 +172,6 @@ function M.build(task)
       root,
       "--server",
       Config.options.rocks.server,
-      "--dev",
       "--lua-version",
       "5.1",
       "install", -- use install so that we can make use of pre-built rocks


### PR DESCRIPTION
## Description

When passing the `--dev` flag to `luarocks`, it will prioritise `dev` versions when resolving dependencies (treating `dev` or `scm` as greater than a SemVer version) if the rockspec doesn't specify an upper version constraint (which is often the case).

Dev packages are often unstable and may cause more problems, especially for Windows users (an example I've seen is git for windows trying and failing to checkout submodules).

For now , a good compromise between too many retries and not retrying at all could be to try `luarocks install` from the root manifest first, but to keep the `--dev` flag in `luarocks make`.

If that still causes problems, it might be better to fall back to `luarocks make` without `--dev` first, and then to try `luarocks ---dev make` as a last resort.
In rocks.nvim, we only fall back to adding the `--dev` flag if the install error message contains the string `"No results matching query were found"`; assuming that stable non-dev packages shouldn't depend on dev packages.
