### PR TITLE
fix(loader): add plugins whose rtp got loaded early to start plugins

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -161,7 +161,7 @@ function M.get_start_plugins()
   ---@type LazyPlugin[]
   local start = {}
   for _, plugin in pairs(Config.plugins) do
-    if not plugin._.loaded and (plugin._.rtp_loaded or plugin.lazy == false) then
+    if not plugin._.loaded and (plugin._.rtp_loaded and plugin.lazy == false) then
       start[#start + 1] = plugin
     end
   end


### PR DESCRIPTION
Commit 34b0126 breaks lazy loading. Change `or` to `and` fixes the bug.
