### PR TITLE
chore(config): update dev.path description

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -67,7 +67,9 @@ M.defaults = {
     hererocks = nil,
   },
   dev = {
-    ---@type string | fun(plugin: LazyPlugin): string directory where you store your local plugin projects
+    -- Directory where you store your local plugin projects. If a function is used,
+    -- the plugin directory (e.g. `~/projects/plugin-name`) must be returned.
+    ---@type string | fun(plugin: LazyPlugin): string
     path = "~/projects",
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}


### PR DESCRIPTION
## Description

In the issue (#1707) I was confused by the description of `dev.path`. I thought functions must also return the general directory for local plugins, but it must be the plugin directory.

## Related Issue(s)

#1707
