### PR TITLE
fix(rocks): add lib64 plugin directory to package.cpath

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -493,8 +493,11 @@ function M.add_to_luapath(plugin)
   local root = Config.options.rocks.root .. "/" .. plugin.name
   local path = root .. "/share/lua/5.1"
   local cpath = root .. "/lib/lua/5.1"
+  local cpath2 = root .. "/lib64/lua/5.1"
+
   package.path = package.path .. ";" .. path .. "/?.lua;" .. path .. "/?/init.lua;"
   package.cpath = package.cpath .. ";" .. cpath .. "/?." .. (jit.os:find("Windows") and "dll" or "so") .. ";"
+  package.cpath = package.cpath .. ";" .. cpath2 .. "/?." .. (jit.os:find("Windows") and "dll" or "so") .. ";"
 end
 
 function M.source(path)


### PR DESCRIPTION
## Description
`package.cpath` is missing the `lib64` directory for plugins that have luarocks dependencies.

## Context
I found this issue when I was working on my new Neovim plugin on my Fedora 39 machine. I added the `luasockets` dependency to rockspec file in my plugin like so:

```
rockspec_format = "3.0"
package = "typeracer.nvim"
version = "scm-1"
source = {
	url = "git+https://github.com/carbon-steel/typeracer.nvim",
}
dependencies = {
	"luasocket",
}
test_dependencies = {
	"nlua",
}
build = {
	type = "builtin",
	copy_directories = {},
}

```

I found that the dynamic libraries from the `luasockets` dependency were installed like so: `/home/username/.local/share/nvim/lazy-rocks/typeracer.nvim/lib64/lua/5.1/socket/core.so`. However, the only entry related to my plugin `typeracer.nvim` was: `/home/glyph/.local/share/nvim/lazy-rocks/typeracer.nvim/lib/lua/5.1/?.so`. The issue is that we only have the plugin's `lib` directory in `package.cpath` and not `lib64`.

I looked through `lazy.nvim`'s code and I think adding the `lib64` directory should fix the issue. I don't know if we also want to worry about `lib32` as well, but so far, this change works for me.