### PR TITLE
fix(view): prevent accidentally changing buffer in lazy window

### DIFF
--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -184,6 +184,9 @@ function M:mount()
     Util.wo(self.win, "wrap", true)
     Util.wo(self.win, "winhighlight", "Normal:LazyNormal")
     Util.wo(self.win, "colorcolumn", "")
+    if vim.fn.exists('&winfixbuf') == 1 then
+      Util.wo(self.win, "winfixbuf", true)
+    end
   end
   opts()
 


### PR DESCRIPTION
## Description
Adds the new `winfixbuf` to the window options of the lazy window. This makes the buffer "sticky", preventing accidentally switching to another buffer while in that window, e.g. via `:edit {some file}`. 

`winfixbuf` is only available on newer nvim versions, so adding the option is wrapped in a condition checking whether it is supported.

## Related Issue(s)
See the PR at nvim core https://github.com/neovim/neovim/issues/12517
