### PR TITLE
fix(completion): check if command string is a prefix of Lazy

### DIFF
--- a/lua/lazy/view/commands.lua
+++ b/lua/lazy/view/commands.lua
@@ -146,7 +146,7 @@ end
 ---@return string, string[]
 function M.parse(args)
   local parts = vim.split(vim.trim(args), "%s+")
-  if parts[1]:find("Lazy") then
+  if vim.startswith("Lazy", parts[1]) then
     table.remove(parts, 1)
   end
   if args:sub(-1) == " " then


### PR DESCRIPTION
Problem: Command completion doesn't work if the command name isn't written in full

Solution: Use vim.startswith to check if the command is a prefix of 'Lazy'

Fixes #1758

