### PR TITLE
Expose winblend floating window option

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -89,6 +89,8 @@ M.defaults = {
     border = "none",
     -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
     backdrop = 60,
+    -- The main window opacity. 0 is fully opaque, 100 is fully transparent.
+    winblend = 0,
     title = nil, ---@type string only works when border is not "none"
     title_pos = "center", ---@type "center" | "left" | "right"
     -- Show pills on top of the Lazy window

--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -16,6 +16,7 @@ local ViewConfig = require("lazy.view.config")
 ---@field ft? string
 ---@field noautocmd? boolean
 ---@field backdrop? float
+---@field winblend? number
 
 ---@class LazyFloat
 ---@field buf number
@@ -55,6 +56,7 @@ function M:init(opts)
     style = "minimal",
     border = Config.options.ui.border or "none",
     backdrop = Config.options.ui.backdrop or 60,
+    winblend = Config.options.ui.winblend or 0,
     zindex = 50,
   }, opts or {})
 
@@ -184,6 +186,7 @@ function M:mount()
     Util.wo(self.win, "wrap", true)
     Util.wo(self.win, "winhighlight", "Normal:LazyNormal")
     Util.wo(self.win, "colorcolumn", "")
+    Util.wo(self.win, "winblend", self.opts.winblend)
   end
   opts()
 


### PR DESCRIPTION
## Description

### Change

Expose Neovim's `winblend` option via `LazyConfig.ui.winblend`

### Motivation

I use several plugins which make use of floating windows (Telescope, ft-term, Mason, Lazy, Triptych) and I'd like to unify their appearance as much as possible, including the use of subtle transparency. Some of the plugins listed already support this, while others don't. So I'm hoping Lazy can be added to that list :)

## Screenshots

<img width="1501" alt="Screenshot 2024-11-16 at 11 24 13" src="https://github.com/user-attachments/assets/fd194d09-1458-43bc-b89a-04c45b185bd5">

