### PR TITLE
ci: use system shell instead of bash

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,3 +1,3 @@
-#!/bin/env bash
+#!/bin/sh
 
 nvim -l tests/minit.lua --minitest


### PR DESCRIPTION
## Description

Change the test script's shebang to #!/bin/sh because Bash isn't ubiquitous on non-GNU systems.

## Related Issue(s)

Fixes #1774 
