### PR TITLE
fix(types): ensure all fields for `LazyPluginBase` are optional

### DIFF
--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -49,10 +49,10 @@
 
 ---@class LazyPluginBase
 ---@field [1] string?
----@field name string display name and name used for plugin config files
+---@field name? string display name and name used for plugin config files
 ---@field main? string Entry module that has setup & deactivate
----@field url string?
----@field dir string
+---@field url? string
+---@field dir? string
 ---@field enabled? boolean|(fun():boolean)
 ---@field cond? boolean|(fun():boolean)
 ---@field optional? boolean If set, then this plugin will not be added unless it is added somewhere else


### PR DESCRIPTION
## Description

After updating lua_ls to [v3.13.3](https://github.com/LuaLS/lua-language-server/releases/tag/3.13.3) noticed my plugin scripts using `@type LazyPluginSpec` now have `missing-fields` warnings.
It seems they have changed how `missing-fields` diagnostics work with inherited types: https://github.com/LuaLS/lua-language-server/commit/7b2d58537fea87d1fefec894ac17b3bd73681e63.

So I suspect we can just make sure all these fields are optional within `LazyPluginBase`.

https://github.com/folke/lazy.nvim/blob/014d1d6d78df4e58f962158e6e00261d8632612c/lua/lazy/types.lua#L50-L55

A majority of the fields within the `PluginSpecBase` class are already optional, so unless these are meant to be required fields, this seems an easy fix.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

![image](https://github.com/user-attachments/assets/a2ad467b-06cb-4fd0-afaf-bae479392eef)