### PR TITLE
fix(types): ensure all fields for `LazyPluginSpec` are optional

### DIFF
--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -75,6 +75,8 @@
 ---@field module? false
 
 ---@class LazyPluginSpec: LazyPluginBase,LazyPluginSpecHandlers,LazyPluginHooks,LazyPluginRef
+---@field name? string display name and name used for plugin config files
+---@field dir? string
 ---@field dependencies? string|string[]|LazyPluginSpec[]
 ---@field specs? string|string[]|LazyPluginSpec[]
 


### PR DESCRIPTION
> After updating lua_ls to [v3.13.3](https://github.com/LuaLS/lua-language-server/releases/tag/3.13.3) noticed my plugin scripts using `@type LazyPluginSpec` now have `missing-fields` warnings.
It seems they have changed how `missing-fields` diagnostics work with inherited types: https://github.com/LuaLS/lua-language-server/commit/7b2d58537fea87d1fefec894ac17b3bd73681e63.

Duplicate offending fields as optional in type `LazyPluginSpec`

Closes: #1842