### PR TITLE
feat(keys): add mapping rhs as description for temporary lazy mappings 

### DIFF
--- a/lua/lazy/core/handler/keys.lua
+++ b/lua/lazy/core/handler/keys.lua
@@ -112,6 +112,11 @@ function M:_add(keys)
   local lhs = keys.lhs
   local opts = M.opts(keys)
 
+  local rhs = keys.rhs -- Work-around lua-language-server type inference.
+  -- Pass string rhs to desc to make it visible before loading the plugin, or we will only see file path to closure
+  -- below.
+  opts.desc = opts.desc or type(rhs) == "string" and rhs or nil
+
   ---@param buf? number
   local function add(buf)
     if M.is_nop(keys) then


### PR DESCRIPTION
## Description

Fixes `:map` not showing what the mapping does until the plugin is loaded.

With lazy mapping `{ "<Leader>f", "<Cmd>FzfLua files<CR>" },` `:map` now shows:

```
n  <Space>f    * <Lua 79: ~/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/keys.lua:126>
                 <Cmd>FzfLua files<CR>
```

How `:map` looks after the plugin is loaded:
`n  <Space>f    * <Cmd>FzfLua files<CR>`

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

