### PR TITLE
feat(config,render): allow customizing the debug icon

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -96,6 +96,7 @@ M.defaults = {
     icons = {
       cmd = " ",
       config = "",
+      debug = "●",
       event = " ",
       favorite = " ",
       ft = " ",

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -759,7 +759,7 @@ function M:debug()
         ---@type string[]
         plugins = vim.tbl_values(plugins)
         table.sort(plugins)
-        self:append("● ", "LazySpecial", { indent = 2 })
+        self:append(Config.options.ui.icons.debug, "LazySpecial", { indent = 2 })
         if handler_type == "keys" then
           for k, v in pairs(Config.plugins[plugins[1]]._.handlers.keys) do
             if k == value then


### PR DESCRIPTION
## Description

lazy.nvim allows users to configure all icons except for the debug icon. This PR enables user to configure the debug icon with `ui.icons.debug`

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/42b02fd9-58e6-4ebc-a1a7-c5e91f07a11a)

After (with config `{ ui = { icons = { debug = ' ' } } }`):

![image](https://github.com/user-attachments/assets/3ade5392-a988-4a10-86fc-f52b41a690c5)


