### PR TITLE
add insecure option to the plugin spec

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -261,6 +261,8 @@ SPEC SOURCE                           *lazy.nvim-🔌-plugin-spec-spec-source*
 
   dev        boolean?   When true, a local plugin directory will be used instead. See
                         config.dev
+
+  insecure   boolean?   When true, SSL certificate verification will be disabled.
   -----------------------------------------------------------------------------------
 A valid spec should define one of `[1]`, `dir` or `url`.
 

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -158,6 +158,11 @@ M.clone = {
       vim.list_extend(args, { "-b", self.plugin.branch })
     end
 
+    if self.plugin.insecure then
+      args[#args + 1] = "-c"
+      args[#args + 1] = "http.sslVerify=false"
+    end
+
     table.insert(args, self.plugin.dir)
 
     if vim.fn.isdirectory(self.plugin.dir) == 1 then


### PR DESCRIPTION
## Description
This PR adds an option to disable SSL certificate verification. Useful if you want to install plugins from a server that uses self-signed certificates (for example a home server).

## Related Issue(s)
None

## Screenshots
None

