### PR TITLE
feat(rockspec): minor changes to rocks detection

### DIFF
--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -260,9 +260,11 @@ function M.find_rockspec(plugin)
   Util.ls(plugin.dir, function(path, name, t)
     if t == "directory" and name == "rockspecs" then
       Util.ls(path, function(path, name, t)
-        rockspec_file = check_file(path, name)
-        if rockspec_file ~= nil then
-          return false
+        if t == "file" then
+          rockspec_file = check_file(path, name)
+          if rockspec_file ~= nil then
+            return false
+          end
         end
       end)
       if rockspec_file ~= nil then

--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -258,7 +258,7 @@ function M.find_rockspec(plugin)
   end
 
   Util.ls(plugin.dir, function(path, name, t)
-    if t == "directory" and name == "rockspecs" then
+    if t == "directory" and (name == "rockspec" or name == "rockspecs") then
       Util.ls(path, function(path, name, t)
         if t == "file" then
           rockspec_file = check_file(path, name)

--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -249,9 +249,10 @@ function M.find_rockspec(plugin)
   local rockspec_file ---@type string?
 
   local check_file = function(path, name)
+    -- match package-(scm|git|dev)-[REV].rockspec
     for _, suffix in ipairs({ "scm", "git", "dev" }) do
-      suffix = suffix .. "-1.rockspec"
-      if name:sub(-#suffix) == suffix then
+      pattern = suffix .. "%-%d+%.rockspec$"
+      if name:find(pattern) then
         return path
       end
     end


### PR DESCRIPTION
## Description

Some lua modules may not put `.rockspec` file at the root of the project, so `lazy.nvim` won't recognize them as rocks. This PR makes it so `lazy.nvim` also scans `rockspec` and `rockspecs` directories (if they exist) for the appropriate `.rockspec`.
Some modules may also have a revision other than 1, so this PR makes it so `lazy.nvim` matches any numerical revision.

## Related Issue(s)

None

## Screenshots

None

