### PR TITLE
feat(docs): skip docs task for read-only directories

### DIFF
--- a/lua/lazy/manage/task/plugin.lua
+++ b/lua/lazy/manage/task/plugin.lua
@@ -87,7 +87,7 @@ M.build = {
 
 M.docs = {
   skip = function(plugin)
-    return not plugin._.is_local and not plugin._.dirty
+    return not plugin._.is_local and not plugin._.dirty or not vim.uv.fs_access(plugin.dir, "W")
   end,
   run = function(self)
     local docs = self.plugin.dir .. "/doc"


### PR DESCRIPTION
## Description

Skip `docs` task for plugins in read-only directories to avoid errors.

This assumes a case where, for example, lazy.nvim references a plugin in the Nix store.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

