### PR TITLE
fix(ui): do not show virt_lines for messages

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -94,7 +94,7 @@ function M:update()
       diag.lnum = diag.row - 1
       return diag
     end, self._diagnostics),
-    { signs = false, virtual_text = true, underline = false }
+    { signs = false, virtual_text = true, underline = false, virtual_lines = false }
   )
 end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

https://github.com/neovim/neovim/pull/31959 has introduced virtual lines for showing diagnostics. If this is enabled (default value), messages from lazy.nvim, such as `update available` are shown as virtual lines in addition to virtual texts.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

* ***before***
  - <img width="592" alt="スクリーンショット 2025-01-27 16 42 27" src="https://github.com/user-attachments/assets/6994ac84-4862-4532-81ee-80f4015181e5" />
* ***after***
  - <img width="585" alt="スクリーンショット 2025-01-27 16 42 58" src="https://github.com/user-attachments/assets/d19f63dc-fb6d-434f-89cf-a0bc49d31c5f" />
