### PR TITLE
fix(options): properly handle dev path as a function

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -679,7 +679,7 @@ will be added to the plugin’s spec.
       dev = {
         -- Directory where you store your local plugin projects. If a function is used,
         -- the plugin directory (e.g. `~/projects/plugin-name`) must be returned.
-        ---@type string | fun(plugin: LazyPlugin): string
+        ---@type string | fun(): string
         path = "~/projects",
         ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
         patterns = {}, -- For example {"folke"}

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -69,7 +69,7 @@ M.defaults = {
   dev = {
     -- Directory where you store your local plugin projects. If a function is used,
     -- the plugin directory (e.g. `~/projects/plugin-name`) must be returned.
-    ---@type string | fun(plugin: LazyPlugin): string
+    ---@type string | fun(): string
     path = "~/projects",
     ---@type string[] plugins that match these patterns will use your local versions instead of being fetched from GitHub
     patterns = {}, -- For example {"folke"}
@@ -286,6 +286,8 @@ function M.setup(opts)
   M.options.root = Util.norm(M.options.root)
   if type(M.options.dev.path) == "string" then
     M.options.dev.path = Util.norm(M.options.dev.path)
+  else
+    M.options.dev.path = Util.norm(M.options.dev.path())
   end
   M.options.lockfile = Util.norm(M.options.lockfile)
   M.options.readme.root = Util.norm(M.options.readme.root)


### PR DESCRIPTION
## Description

The documentation for `dev.path` config option states

```
        -- Directory where you store your local plugin projects. If a function is used,
        -- the plugin directory (e.g. `~/projects/plugin-name`) must be returned.
        ---@type string | fun(plugin: LazyPlugin): string

```

However, when trying to use a function to return the path, it failed. I need it to have a different behavior when neovim is running remotely in a docker container vs my local machine.

Upon investigation, it appears that this behavior was not implemented. The proposed implementation works, but I'm no lua developper, so feel free to change it / suggest changes. In particular, I couldn't figure out where to get a reference to the `LazyPlugin` instance to be passed to the function. As I didn't see why it would be needed, I simply removed the argument.