### PR TITLE
fix(types): add optional return value for `LazyKeysSpec` rhs

### DIFF
--- a/lua/lazy/core/handler/keys.lua
+++ b/lua/lazy/core/handler/keys.lua
@@ -11,7 +11,7 @@ local Util = require("lazy.core.util")
 
 ---@class LazyKeysSpec: LazyKeysBase
 ---@field [1] string lhs
----@field [2]? string|fun()|false rhs
+---@field [2]? string|fun():string?|false rhs
 ---@field mode? string|string[]
 
 ---@class LazyKeys: LazyKeysBase


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

when `expr=true` the rhs function should return a string.

example

```lua
{
    keys = {
        {
            '<leader>j',
            function()
                return require('dial.map').inc_normal()
            end,
            expr = true,
            desc = 'Increment value',
        }
    }
}
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
