### PR TITLE
refactor(keys): use allowlist for valid opts

### DIFF
--- a/lua/lazy/core/handler/keys.lua
+++ b/lua/lazy/core/handler/keys.lua
@@ -24,7 +24,18 @@ local Util = require("lazy.core.util")
 ---@class LazyKeysHandler:LazyHandler
 local M = {}
 
-local skip = { mode = true, id = true, ft = true, rhs = true, lhs = true }
+local valid = {
+  remap = true,
+  noremap = true,
+  buffer = true,
+  silent = true,
+  nowait = true,
+  expr = true,
+  unique = true,
+  script = true,
+  desc = true,
+  replace_keycodes = true,
+}
 
 ---@param value string|LazyKeysSpec
 ---@param mode? string
@@ -94,7 +105,7 @@ function M.opts(keys)
   local opts = {} ---@type LazyKeysBase
   ---@diagnostic disable-next-line: no-unknown
   for k, v in pairs(keys) do
-    if type(k) ~= "number" and not skip[k] then
+    if type(k) ~= "number" and valid[k] then
       ---@diagnostic disable-next-line: no-unknown
       opts[k] = v
     end


### PR DESCRIPTION
### Summary
This pull request refactors the `opts` function in `LazyKeysHandler` to use an allowlist for valid options instead of a blacklist. This change enhances code clarity and maintainability by explicitly defining accepted options, reducing the risk of unintentional errors from unsupported keys.

### Changes Made
- Replaced the previous blacklist approach with an allowlist for valid keys in the `opts` function of `LazyKeysHandler`.

### Reason
I provided this pull request to allow the addition of which-key's key specifications to each plugin's `keys` attribute. The previous blacklist method restricted the addition of attributes that weren't explicitly allowed, such as the `icon` attribute, resulting in errors from Neovim. By using an allowlist, we can avoid these issues and freely include all necessary attributes in the key specifications. Following is an example of what we can do after applying the pull request.

#### In `nvim/lua/plugins/notify.lua`
```lua
return {
  "rcarriga/nvim-notify",
  dependencies = {
    "nvim-telescope/telescope.nvim",
  },
  keys = {
    { "<leader>n", group = "Notifications", icon = "󰨄" },
    { "<leader>nm", ":Notifications<CR>", desc = "Messages" },
    { "<leader>ng", ":Telescope notify<CR>", desc = "Grep", icon = "" },
    { "<leader>nd", ':lua require"notify".dismiss()<CR>', desc = "Dismiss", icon = "󰱝" },
  },
  init = function()
    vim.notify = require("notify")
  end,
}
```

#### In `nvim/lua/plugins/which-key.lua`
```lua
return {
  -- Provides keybindings for all your plugins
  "folke/which-key.nvim",
  event = "VeryLazy",
  init = function()
    vim.o.timeout = true
    vim.o.timeoutlen = 500
  end,
  config = function(_, opts)
    local wk = require("which-key")
    wk.setup(opts)

    local specs = {
      -- custom specs
    }
    ---@cast specs wk.Spec[]
    for _, plugin in pairs(require("lazy.core.config").plugins) do
      local keys = plugin.keys
      if keys then
        keys = vim.deepcopy(keys)
        if plugin.lazy then
          -- When plugin.lazy is true, we set key[2] to nil for each key mapping.
          -- This allows lazy.nvim to use the key mappings as triggers for loading the plugin,
          -- rather than executing the original RHS (right-hand side) function,
          -- which may not be available until the plugin is loaded.
          for _, key in ipairs(keys) do
            key[2] = nil
          end
        end
        vim.list_extend(specs, keys)
      end
    end
    wk.add(specs)
  end,
}
```