### PR TITLE
fix(util): use vim.ui.open to open uri

### DIFF
--- a/lua/lazy/util.lua
+++ b/lua/lazy/util.lua
@@ -26,13 +26,6 @@ function M.open(uri, opts)
     return M.float({ style = "", file = uri })
   end
   if vim.fn.has('nvim-0.10.0') == 1 then
-    local ret = vim.fn.jobstart(cmd, { detach = true })
-    if ret <= 0 then
-      local msg = {
-        "Failed to open uri",
-        ret,
-        vim.inspect(cmd),
-      }
     local cmd, err = vim.ui.open(uri)
     if cmd then
       cmd:wait()
@@ -65,6 +58,15 @@ function M.open(uri, opts)
         cmd = { "open", uri }
       end
     end
+      local ret = vim.fn.jobstart(cmd, { detach = true })
+      if ret <= 0 then
+        local msg = {
+          "Failed to open uri",
+          ret,
+          vim.inspect(cmd),
+        }
+        vim.notify(table.concat(msg, "\n"), vim.log.levels.ERROR)
+      end
   end
 end
 


### PR DESCRIPTION
fixes #1947

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

In WSL, pressing `K` over a commit id or URL in the `:Lazy` window gives error
```
E5108: Error executing lua: Vim:E475: Invalid value from argument cmd: 'open' is not executable
```

Implementing the Util.open using `vim.ui.open` fixes this issue, however I've only tested it on windows.
Let me know if there is any concern that I could be missing.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
--> Fixes #1947 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
NA
