### PR TITLE
fix(diff): set `--git-dir` argument to overwrite user defined workspace `$GIT_DIR`

### DIFF
--- a/lua/lazy/view/diff.lua
+++ b/lua/lazy/view/diff.lua
@@ -23,18 +23,18 @@ M.handlers = {
 
   ---@type LazyDiffFun
   ["diffview.nvim"] = function(plugin, diff)
-    local args
+    local args = "--git-dir=.git" .. " " .. ("-C=%s"):format(plugin.dir) .. " "
     if diff.commit then
-      args = ("-C=%s"):format(plugin.dir) .. " " .. diff.commit .. "^!"
+      args = args .. diff.commit .. "^!"
     else
-      args = ("-C=%s"):format(plugin.dir) .. " " .. diff.from .. ".." .. diff.to
+      args = args .. diff.from .. ".." .. diff.to
     end
     vim.cmd("DiffviewOpen " .. args)
   end,
 
   ---@type LazyDiffFun
   git = function(plugin, diff)
-    local cmd = { "git" }
+    local cmd = { "git", "--git-dir=.git" }
     if diff.commit then
       cmd[#cmd + 1] = "show"
       cmd[#cmd + 1] = diff.commit
@@ -48,7 +48,7 @@ M.handlers = {
 
   ---@type LazyDiffFun
   terminal_git = function(plugin, diff)
-    local cmd = { "git" }
+    local cmd = { "git", "--git-dir=.git" }
     if diff.commit then
       cmd[#cmd + 1] = "show"
       cmd[#cmd + 1] = diff.commit


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

If the workspace environment contains `$GIT_DIR` it breaks diff view of Lazy.nvim. Therefore I would advise to always set the Git dir explicitely to the plugin dir.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
