### PR TITLE
fix: do not create a border for the backdrop with vim.o.winborder

### DIFF
--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -149,6 +149,7 @@ function M:mount()
       row = 0,
       col = 0,
       style = "minimal",
+      border = "none",
       focusable = false,
       zindex = self.opts.zindex - 1,
     })


### PR DESCRIPTION
## Description

When using the new `vim.o.winborder` option to set a border for every floating window, it adds a border to the backdrop. So i forced the border to be `border = "none"`

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

with `vim.o.border = "rounded"`

without the fix:
![20250323_14h16m59s_grim](https://github.com/user-attachments/assets/efcd4374-1f95-40fa-9313-4cf9ec056a6c)

with the fix:
![20250323_14h17m17s_grim](https://github.com/user-attachments/assets/af130a19-e237-4751-8d7b-8dfbd8235195)




