### PR TITLE
fix(rockspec): adjusted luarocks executable to contain the appropriate extension on windows

### DIFF
--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -25,6 +25,27 @@ M.rewrites = {
 
 M.python = { "python3", "python" }
 
+---@class LuaRocks
+M.luarocks = {}
+
+-- check which executable to call for luarocks, considering windows exceptions
+-- @return string
+function M.luarocks.execname()
+  local luarocks = "luarocks"
+  if Util.is_win then
+    local luarocks_win = "luarocks.exe"
+    if vim.fn.executable(luarocks_win) == 1 then
+      luarocks = luarocks_win
+    else
+      luarocks_win = "luarocks.bat"
+      if vim.fn.executable(luarocks_win) == 1 then
+        luarocks = luarocks_win
+      end
+    end
+  end
+  return luarocks
+end
+
 ---@class HereRocks
 M.hererocks = {}
 
@@ -87,7 +108,8 @@ function M.check(opts)
       )
     end
   else
-    ok = Health.have("luarocks", opts)
+    local luarocks = M.luarocks.execname()
+    ok = Health.have(luarocks, opts)
     Health.have(
       { "lua5.1", "lua", "lua-5.1" },
       vim.tbl_extend("force", opts, {
@@ -133,7 +155,7 @@ function M.build(task)
   end
 
   local env = {}
-  local luarocks = "luarocks"
+  local luarocks = M.luarocks.execname()
   if Config.hererocks() then
     -- hererocks is still building, so skip for now
     -- a new build will happen in the next round
@@ -151,9 +173,6 @@ function M.build(task)
     env = {
       PATH = table.concat(path, sep),
     }
-    if Util.is_win then
-      luarocks = luarocks .. ".bat"
-    end
   end
 
   local pkg = task.plugin._.pkg


### PR DESCRIPTION
This fixes the problems with `:checkhealth` and package building on Windows when using luarocks.
Previously it wasn't adding the correct extension, depending on the user setup.

Remarks:
1. LuaRocks has 2 different distribution packages, one that uses a `.bat` and another one that uses a `.exe`.

2. `vim.fn.executable()` will work if the extension is omitted, but `Process.exec()` will fail

This should solve most of the Windows users headaches when using LuaRocks with lazy.nvim

![image](https://github.com/user-attachments/assets/f02e365c-e790-401d-a322-269869e2c264)
