### PR TITLE
Update branch name in documentation

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -40,7 +40,7 @@ require("config.lazy")
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
   local lazyrepo = "https://github.com/folke/lazy.nvim.git"
-  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=main", lazyrepo, lazypath })
   if vim.v.shell_error ~= 0 then
     vim.api.nvim_echo({
       { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
@@ -105,7 +105,7 @@ For more info see [Structuring Your Plugins](/usage/structuring)
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
   local lazyrepo = "https://github.com/folke/lazy.nvim.git"
-  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=main", lazyrepo, lazypath })
   if vim.v.shell_error ~= 0 then
     vim.api.nvim_echo({
       { "Failed to clone lazy.nvim:\n", "ErrorMsg" },


### PR DESCRIPTION
## Description
The installation documentation incorrectly points to the `stable` branch in the example. However, if you look at the lazy.nvim list of branches, you won't find a `stable` branch[1]. This commit changes the example to point to `main` branch, which does exist[2].

[1] https://github.com/folke/lazy.nvim/branches/all?query=stable
[2] https://github.com/folke/lazy.nvim/branches/all?query=main

Without this, a user who incorrectly uses the `stable` branch instead of `main` will get the error `fatal: couldn't find remote ref refs/heads/stable` will pop-up when executing `:Lazy sync`.

Found the issue whilst doing a local `:Lazy sync` troubleshooting. However, I ran into the issue described in #1971, which means updating my own local `lazy.lua` (from the example) did nothing. I ended up solving the problem by blowing away Lazy altogether via: `rm -rf ~/.local/share/nvim/lazy/lazy.nvim`.

## Related Issue(s)
This is directly related to #1971, which was incorrectly closed due to inactivity.