### PR TITLE
fix(docusaurus): respect users' preferred color scheme

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -57,6 +57,11 @@ const config: Config = {
   ],
 
   themeConfig: {
+    colorMode: {
+      defaultMode: "light",
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
     // Replace with your project's social card
     image: "img/docusaurus-social-card.jpg",
     navbar: {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
these are some minor changes to the docusaurus config so that its theme corresponds to the system one instead of always defaulting to the light mode; i.e. if you have dark mode in your OS, then the docs will be dark too (unless you manually switch the theme)

however, it's still going to default to the light mode on systems which do not support dark/light/auto modes
(or let me know if you want the dark to be the default for such cases, i'll push the change)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

