### PR TITLE
feat: dynamically determine lazy.nvim origin spec

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -315,6 +315,18 @@ function M.find_local_spec()
   end
 end
 
+function M.find_actual_origin_spec()
+  local info = debug.getinfo(2, "S")
+  local current_file = info.source:sub(2) -- remove the leading '@'
+  local current_dir = vim.fn.fnamemodify(current_file, ":h")
+  local git_root = Util.find_git_root(current_dir)
+  local Git = require("lazy.manage.git")
+
+  return {
+    url = Git.get_origin(git_root),
+  }
+end
+
 function M.load()
   M.loading = true
   -- load specs
@@ -326,7 +338,7 @@ function M.load()
     vim.deepcopy(Config.options.spec),
   }
   specs[#specs + 1] = M.find_local_spec()
-  specs[#specs + 1] = { "folke/lazy.nvim" }
+  specs[#specs + 1] = M.find_actual_origin_spec()
 
   Config.spec:parse(specs)
 

--- a/lua/lazy/core/util.lua
+++ b/lua/lazy/core/util.lua
@@ -228,6 +228,17 @@ function M.walk(path, fn)
   end)
 end
 
+---@param path string
+function M.find_git_root(path)
+  local current = path
+  while current and current ~= "/" do
+    if vim.fn.isdirectory(current .. "/.git") == 1 then
+      return current
+    end
+    current = vim.fn.fnamemodify(current, ":h")
+  end
+end
+
 ---@param root string
 ---@param fn fun(modname:string, modpath:string)
 ---@param modname? string


### PR DESCRIPTION
## Description

Replace hardcoded repository reference with dynamic origin detection to support different lazy.nvim forks automatically.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
![image](https://github.com/user-attachments/assets/fec553d7-3ee8-452f-9f11-a44e9b55d89f)

<!-- Add screenshots of the changes if applicable. -->

