### PR TITLE
fix(health, rockspec): accept Lua 5.1+ for luarocks compatibility

### DIFF
--- a/lua/lazy/health.lua
+++ b/lua/lazy/health.lua
@@ -43,7 +43,7 @@ function M.have(cmd, opts)
       else
         local version = vim.trim(out[1] or "")
         version = version:gsub("^%s*" .. vim.pesc(c) .. "%s*", "")
-        if opts.version_pattern and not version:find(opts.version_pattern, 1, true) then
+        if opts.version_pattern and not version:find(opts.version_pattern) then
           opts.warn(("`%s` version `%s` needed, but found `%s`"):format(c, opts.version_pattern, version))
         else
           found = ("{%s} `%s`"):format(c, version)
@@ -59,7 +59,7 @@ function M.have(cmd, opts)
     (opts.optional and opts.warn or opts.error)(
       ("{%s} %snot installed"):format(
         table.concat(cmd, "} or {"),
-        opts.version_pattern and "version `" .. opts.version_pattern .. "` " or ""
+        opts.version_pattern and "version matching `" .. opts.version_pattern .. "` " or ""
       )
     )
   end

--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -82,7 +82,7 @@ function M.check(opts)
         M.hererocks.bin("lua"),
         vim.tbl_extend("force", opts, {
           version = "-v",
-          version_pattern = "5.1",
+          version_pattern = "5%.[1-9]",
         })
       )
     end
@@ -92,7 +92,7 @@ function M.check(opts)
       { "lua5.1", "lua", "lua-5.1" },
       vim.tbl_extend("force", opts, {
         version = "-v",
-        version_pattern = "5.1",
+        version_pattern = "5%.[1-9]",
       })
     )
   end


### PR DESCRIPTION
## Description

Previously, lazy.nvim health checks required exactly Lua 5.1, causing warnings on systems with newer Lua versions (5.2, 5.3, 5.4). This was unnecessarily restrictive since LuaRocks can run on any Lua version 5.1+ to build packages.

Its true that Neovim plugins must be Lua 5.1 compatible (due to LuaJIT), but the `--lua-version 5.1` flag tells luarocks to build for 5.1.

After some light testing, I verified a system with Lua 5.4 should be able to build Lua 5.1-compatible packages just fine.
I tested with [image.nvim](https://github.com/3rd/image.nvim) (shown in screenshot below).

The key point is that this removes false warnings while maintaining the same safety guarantees - LuaRocks with any modern Lua version can still build packages targeting Lua 5.1 compatibility for Neovim.

## Related Issue(s)
Fixes: #2020
Fixes: #1570

## Screenshots

To test, I added the following to my init.lua:

```lua
  -- image.nvim - Image viewer that has a proper rockspec file
  {
    '3rd/image.nvim',
    build = "rockspec", -- This plugin has image.nvim-scm-1.rockspec in its repo!
    config = function()
      -- image.nvim shows images in Neovim
      -- require('image').setup({
      --   -- configuration options
      -- })
    end,
  },
```

<img width="657" height="434" alt="Screenshot 2025-07-14 at 5 25 58 PM" src="https://github.com/user-attachments/assets/51d5cbee-77cc-485c-b580-5fed6a4ec049" />

