### PR TITLE
fix(core): set init_done before sourcing after directories

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -143,6 +143,10 @@ function M.startup()
 
   -- 4. load after plugins
   Util.track({ start = "after" })
+  -- Set init_done here so plugins loaded afterwards know that
+  -- they are not able to add to init anymore
+  M.init_done = true
+  Util.track()
   for _, path in
     ipairs(vim.opt.rtp:get() --[[@as string[] ]])
   do
@@ -150,10 +154,6 @@ function M.startup()
       M.source_runtime(path, "plugin")
     end
   end
-  Util.track()
-
-  M.init_done = true
-
   Util.track()
 end
 


### PR DESCRIPTION
## Summary
This PR fixes a timing issue where a plugin loaded during the after directory scan would have its own after directory skipped.

## Description
This moves the init_done variable before the after directory is sourced. This fixes an issue when a plugin is sourced while the runtime path list is being looped to find all after directories. If init_done is not set, the code assumes that its own after directory will be sourced in this loop, however since it already started this is impossible.

## Example Scenario
This fixes an error for me when cmp_luasnip loads, which in its after/plugin directory it calls 
require("cmp"). This causes nvim-cmp and all of its dependencies to load, however none of these after directories would get sourced.