### PR TITLE
fix(plugin): protect dev plugins from cleanup

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -237,7 +237,7 @@ function M.update_state()
         or plugin.cmd
       plugin.lazy = lazy and true or false
     end
-    if plugin.virtual then
+    if plugin.virtual or (plugin.dev and plugin.dir ~= "") then
       plugin._.is_local = true
       plugin._.installed = true -- local plugins are managed by the user
     elseif plugin.dir:find(Config.options.root, 1, true) == 1 then


### PR DESCRIPTION
## Description

Dev plugins (`dev = true`) with local directories (`dir != ''`) should not be deleted during cleanup operations, even when located within the lazy root directory. This enables the workflow of developing plugins locally in the same location where they would be installed from upstream.

---

Let me know if there is a design consideration I'm missing. Thanks!