### PR TITLE
fix(config): runtimepath reset was sometimes picking wrong lib: path

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -299,8 +299,7 @@ function M.setup(opts)
   M.me = debug.getinfo(1, "S").source:sub(2)
   M.me = Util.norm(vim.fn.fnamemodify(M.me, ":p:h:h:h:h"))
   local lib = vim.fn.fnamemodify(vim.v.progpath, ":p:h:h") .. "/lib"
-  lib = vim.uv.fs_stat(lib .. "64") and (lib .. "64") or lib
-  lib = lib .. "/nvim"
+  lib = vim.uv.fs_stat(lib .. "64/nvim") and (lib .. "64/nvim") or lib .. "/nvim"
   if M.options.performance.rtp.reset then
     ---@type vim.Option
     vim.opt.rtp = {


### PR DESCRIPTION

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
  - Fixes #2041
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
