### PR TITLE
chore(example): replace archived dressing.nvim with nvim-surround

### DIFF
--- a/lua/lazy/example.lua
+++ b/lua/lazy/example.lua
@@ -57,7 +57,7 @@ return {
 
   -- you can use the VeryLazy event for things that can
   -- load later and are not important for the initial UI
-  { "stevearc/dressing.nvim", event = "VeryLazy" },
+  { "kylechui/nvim-surround", event = "VeryLazy" },
 
   {
     "Wansmer/treesj",


### PR DESCRIPTION
## Description

Replace the archived [`stevearc/dressing.nvim`](https://github.com/stevearc/dressing.nvim) entry in `lua/lazy/example.lua` with `kylechui/nvim-surround`.

The example plugin list is meant to showcase common lazy-loading patterns. Since `dressing.nvim` has been archived, keeping it in the reference example may confuse new users. `kylechui/nvim-surround` is an actively maintained plugin and still a simple, event-lazy-loadable example, so it is a suitable drop-in demonstration for the `VeryLazy` event.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

