### PR TITLE
fix(rockspec): lua 5.1 detection on FreeBSD

### DIFF
--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -89,7 +89,7 @@ function M.check(opts)
   else
     ok = Health.have("luarocks", opts)
     Health.have(
-      { "lua5.1", "lua", "lua-5.1" },
+      { "lua5.1", "lua", "lua-5.1", "lua51" },
       vim.tbl_extend("force", opts, {
         version = "-v",
         version_pattern = "5.1",


### PR DESCRIPTION
FreeBSD installs lua 5.1 binary as `lua51`. Add this to the list of possible binary names.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

