### PR TITLE
feat(ui): highlight reverted breaking changes as a breaking change.

### DIFF
--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -526,7 +526,7 @@ function M:log(task)
     for _, line in ipairs(lines) do
       local ref, msg, time = line:match("^(%w+) (.*) (%(.*%))$")
       if msg then
-        if msg:find("^%S+!:") then
+        if msg:find("^%S+!:") or msg:find("^Revert \"%S+!:") then
           self:diagnostic({ message = "Breaking Changes", severity = vim.diagnostic.severity.WARN })
         end
         self:append(ref:sub(1, 7) .. " ", "LazyCommit", { indent = 6 })

--- a/lua/lazy/view/sections.lua
+++ b/lua/lazy/view/sections.lua
@@ -46,7 +46,7 @@ return {
           return
         end
         for _, line in ipairs(vim.split(task:output(), "\n")) do
-          if line:find("^%w+ %S+!:") then
+          if line:find("^%w+ %S+!:") or line:find("^%w+ Revert \"%S+!:")then
             return true
           end
         end


### PR DESCRIPTION
## Description

A plugin I was using had a breaking change. I updated and adjusted my config as required. Some time later, the plugin reverted this commit again. I missed that when updating again because for said plugin the author is usually diligent about using conventional-commits for indicating breaking changes, so I did not read the changes too closely when I saw no breaking changes highlighted.

This updates the breaking-change detection regex to detect both commits  of the form `feat!: ...` and `Revert "feat!: ...`

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

None that I am aware of.

## Screenshots

Without this change:
<img width="1445" height="136" alt="image" src="https://github.com/user-attachments/assets/28d5a710-c555-41ab-a5bb-fd2869431a90" />

With this change:
<img width="1445" height="136" alt="image" src="https://github.com/user-attachments/assets/7eeef3a1-b394-4c60-b80a-39c1e6933583" />


