### PR TITLE
fix(ui): set border=none for backdrop window

### DIFF
--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -151,6 +151,7 @@ function M:mount()
       style = "minimal",
       focusable = false,
       zindex = self.opts.zindex - 1,
+      border = "none",
     })
     vim.api.nvim_set_hl(0, "LazyBackdrop", { bg = "#000000", default = true })
     Util.wo(self.backdrop_win, "winhighlight", "Normal:LazyBackdrop")


### PR DESCRIPTION
## Description

When `'winborder'` is set, that value is used for the border of the backdrop window from the `:Lazy` UI which might look a little funny for an element in the background. This PR overrides the border to `"none"` for the backdrop window.

## Related Issue(s)

Related to #1951

## Screenshots

Before:
<img width="1114" height="624" alt="image" src="https://github.com/user-attachments/assets/0cc17f83-2c6f-45a6-b045-386ba556075e" />

After:
<img width="1114" height="624" alt="image" src="https://github.com/user-attachments/assets/f1d3f29a-69d4-4c27-bc51-4147add9cf6f" />

