### PR TITLE
feat(ui): respect 'winborder'

### DIFF
--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -86,7 +86,7 @@ M.defaults = {
     size = { width = 0.8, height = 0.8 },
     wrap = true, -- wrap the lines in the ui
     -- The border to use for the UI window. Accepts same border values as |nvim_open_win()|.
-    border = "none",
+    border = nil, ---@type string|string[]|nil
     -- The backdrop opacity. 0 is fully opaque, 100 is fully transparent.
     backdrop = 60,
     title = nil, ---@type string only works when border is not "none"

--- a/lua/lazy/view/float.lua
+++ b/lua/lazy/view/float.lua
@@ -53,7 +53,7 @@ function M:init(opts)
   self.opts = vim.tbl_deep_extend("force", {
     size = Config.options.ui.size,
     style = "minimal",
-    border = Config.options.ui.border or "none",
+    border = Config.options.ui.border,
     backdrop = Config.options.ui.backdrop or 60,
     zindex = 50,
   }, opts or {})


### PR DESCRIPTION
## Description

This PR allows `'winborder'` to inform how the border of the main UI window is displayed.

- When `ui.border` is set, its value is used
- Otherwise if `'winborder'` is set, its value is used
- If neither is set, then the implicit default `'winborder'` is used (`"none"`, same as the old `ui.border` default)

Notably, users who set `ui.border` or do not set `'winborder'` will see no changes.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Fixes #1951

## Screenshots

Both with`:set winborder=single` and `ui.border` unset.

(The border surrounding the backdrop window is being addressed in #2072.)

Before:
<img width="1008" height="627" alt="image" src="https://github.com/user-attachments/assets/927591ef-87b2-4739-8c11-255a803ef2ee" />

After:
<img width="1008" height="627" alt="image" src="https://github.com/user-attachments/assets/d769201c-8b71-452b-bce7-c1bbdb9c85d6" />

