### PR TITLE
fix(git): make check_pinned work as intended

### DIFF
--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -55,7 +55,7 @@ local M = {}
 M.log = {
   ---@param opts {updated?:boolean, check?: boolean}
   skip = function(plugin, opts)
-    if opts.check and plugin.pin then
+    if opts.check and plugin.pin and not Config.options.checker.check_pinned then
       return true
     end
     if opts.updated and not (plugin._.updated and plugin._.updated.from ~= plugin._.updated.to) then


### PR DESCRIPTION
Skip "git.log" when check and pin is true if check_pinned isn't enabled. Otherwise, the checker will not actually check pinned plugins but silently skip them.
