### PR TITLE
feat(loader): handle hyphens in file names when deactivating

### DIFF
--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -238,7 +238,7 @@ function M.deactivate(plugin)
   -- clear vim.g.loaded_ for plugins
   Util.ls(plugin.dir .. "/plugin", function(_, name, type)
     if type == "file" then
-      vim.g["loaded_" .. name:gsub("%..*", "")] = nil
+      vim.g["loaded_" .. name:gsub("%..*", ""):gsub("-", "_")] = nil
     end
   end)
   -- set as not loaded


### PR DESCRIPTION
## Description

When deactivating plugins `vim.g.loaded_` variables are cleared based on a common pattern plugins use to avoid multiple initializing. The current logic handles most cases, except when a lua file has a hyphen, in which case it is unlikely to clear the correct variable. 

## Examples

| Plugin / File | Current | Actual |
| ------------- | ------- | ------ |
| nvim-treesitter / [nvim-treesitter.lua](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/plugin/nvim-treesitter.lua) | `loaded_nvim-treesitter` | `loaded_nvim_treesitter` |
| neo-tree.nvim / [neo-tree.lua](https://github.com/nvim-neo-tree/neo-tree.nvim/blob/main/plugin/neo-tree.lua) | `loaded_neo-tree` | `loaded_neo_tree` |
| lsp-zero.nvim / [lsp-zero.lua](https://github.com/VonHeikemen/lsp-zero.nvim/blob/v4.x/plugin/lsp-zero.lua) | `loaded_lsp-zero` | `loaded_lsp_zero` |
| fzf-lua / [fzf-lua.lua](https://github.com/ibhagwan/fzf-lua/blob/main/plugin/fzf-lua.lua) | `loaded_fzf-lua` | `loaded_fzf_lua` |
| cellular-automaton.nvim / [cellular-automaton.lua](https://github.com/Eandrju/cellular-automaton.nvim/blob/main/plugin/cellular-automaton.lua) | `loaded_cellular-automaton` | `loaded_cellular_automaton` |
| rest.nvim / [rest-nvim.lua](https://github.com/rest-nvim/rest.nvim/blob/main/plugin/rest-nvim.lua) | `loaded_rest-nvim` | `loaded_rest_nvim` |
| rainbow-delimiters.nvim / [rainbow-delimiters.lua](https://github.com/HiPhish/rainbow-delimiters.nvim/blob/master/plugin/rainbow-delimiters.lua) | `loaded_rainbow-delimiters` | `loaded_rainbow_delimiters` |
| cosmic-ui / [cosmic-ui.lua](https://github.com/CosmicNvim/cosmic-ui/blob/main/plugin/cosmic-ui.lua) | `loaded_cosmic-ui` | `loaded_cosmic_ui` |
| compiler-explorer.nvim / [compiler-explorer.lua](https://github.com/krady21/compiler-explorer.nvim/blob/master/plugin/compiler-explorer.lua) | `loaded_compiler-explorer` | `loaded_compiler_explorer` |
| vim-coach.nvim / [vim-coach.lua](https://github.com/shahshlok/vim-coach.nvim/blob/master/plugin/vim-coach.lua) | `loaded_vim-coach` | `loaded_vim_coach` |
| cd-project.nvim / [cd-project.lua](https://github.com/LintaoAmons/cd-project.nvim/blob/main/plugin/cd-project.lua) | `loaded_cd-project` | `loaded_cd_project` |
| nvim-rooter.lua / [nvim-rooter.lua](https://github.com/notjedi/nvim-rooter.lua/blob/main/plugin/nvim-rooter.lua) | `loaded_nvim-rooter` | `loaded_nvim_rooter` |
| telescope-alternate.nvim / [telescope-alternate.lua](https://github.com/otavioschwanck/telescope-alternate.nvim/blob/master/plugin/telescope-alternate.lua) | `loaded_telescope-alternate` | `loaded_telescope_alternate` |
| diagnostic-hover.nvim / [diagnoistic-hover.lua](https://github.com/WeiTing1991/diagnostic-hover.nvim/blob/main/plugin/diagnoistic-hover.lua) | `loaded_diagnostic-hover` | `loaded_diagnostic_hover` |

> [!NOTE]
> I looked through the first 10 pages of [top](https://dotfyle.com/neovim/plugins/top) and [trending](https://dotfyle.com/neovim/plugins/trending) plugins from dotfyle and the results of a targeted github [search](https://github.com/search?q=path%3Aplugin%2F*-*.lua+vim.g+loaded&type=code)
> I found no counter examples, if the plugin file had a hyphen and used a `vim.g.loaded_` variable, the variable always used underscores instead