### PR TITLE
feat(git): check semver tags

### DIFF
--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -2,6 +2,7 @@ local Async = require("lazy.async")
 local Config = require("lazy.core.config")
 local Git = require("lazy.manage.git")
 local Lock = require("lazy.manage.lock")
+local Semver = require("lazy.manage.semver")
 local Util = require("lazy.util")
 
 local throttle = {}
@@ -98,6 +99,13 @@ M.log = {
             local last_commit = Git.get_commit(self.plugin.dir, target.branch, true)
             if not Git.eq(info, { commit = last_commit }) then
               self.plugin._.outdated = true
+            end
+          end
+          if Config.options.checker.check_tags and self.plugin and target.tag then
+            local latest = Semver.last(Git.get_versions(self.plugin.dir, "*"))
+            if latest and target.tag ~= latest.tag then
+              self.plugin._.outdated = true
+              -- vim.print(target.tag .. " -> " .. latest.tag)
             end
           end
         else


### PR DESCRIPTION
## Description

As well described in #1729, a way to detect outdated pinned plugins is `check_pinned` but doesn't help much for semver ranges. This change adds a `check_tags` option under `checker` to mark plugins as outdated if their last tag differs.

This could be improved to show the new tag but I am not sure how to render it and this works for me as is.

Configuration:

```lua
require('lazy').setup({
  checker = {
    enabled = true,
    check_tags = true,
  },
})
```

Example plugin:

```lua
{
  'stevearc/overseer.nvim',
  version = 'v1.x',
  opts = {},
}
```

## Related Issue(s)

- Fixes #1729

## Screenshots

<img width="1552" height="302" alt="outdated-overseer" src="https://github.com/user-attachments/assets/84adc0cb-6144-472d-bb79-c6e430f3c8c2" />