### PR TITLE
fix(pkg): mark cache dirty when plugin directory changes

### DIFF
--- a/lua/lazy/core/meta.lua
+++ b/lua/lazy/core/meta.lua
@@ -336,6 +336,8 @@ function M:fix_pkgs()
       -- check if plugin is still in the same directory
       if plugin.dir ~= dir then
         self.fragments:del(fid)
+        -- mark pkg cache as dirty so it gets rebuilt with the new directory
+        Pkg.dirty = true
       end
     end
   end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

When a plugin switches to dev mode, `fix_pkgs()` was deleting the stale package fragment but not marking `Pkg.dirty`. This prevented the cache from being rebuilt with the dev directory, so `lazy.lua` files in dev directories were never loaded.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
None

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
N/A
