### PR TITLE
fix(keys): update keys function signature to include LazyKeysSpec arguments

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -347,7 +347,7 @@ SPEC LAZY LOADING               *lazy.nvim-🔌-plugin-spec-spec-lazy-loading*
              fun(self:LazyPlugin, ft:string[]):string[]                       
 
   keys       string? or string[] or LazyKeysSpec[] or                         Lazy-load on key mapping
-             fun(self:LazyPlugin, keys:string[]):(string \| LazyKeysSpec)[]   
+             fun(self:LazyPlugin, keys:(string \| LazyKeysSpec)[]):(string \| LazyKeysSpec)[]   
   --------------------------------------------------------------------------------------------------------------------
 Refer to the Lazy Loading <./lazy_loading.md> section for more information.
 

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -72,7 +72,7 @@
 ---@field event? string[]|string|LazyEventSpec[]|fun(self:LazyPlugin, event:string[]):string[]
 ---@field cmd? string[]|string|fun(self:LazyPlugin, cmd:string[]):string[]
 ---@field ft? string[]|string|fun(self:LazyPlugin, ft:string[]):string[]
----@field keys? string|string[]|LazyKeysSpec[]|fun(self:LazyPlugin, keys:string[]):((string|LazyKeys)[])
+---@field keys? string|string[]|LazyKeysSpec[]|fun(self:LazyPlugin, keys:(string|LazyKeysSpec)[]):((string|LazyKeysSpec)[])
 ---@field module? false
 
 ---@class LazyPluginSpec: LazyPluginBase,LazyPluginSpecHandlers,LazyPluginHooks,LazyPluginRef


### PR DESCRIPTION
## Description

The function in keys may receive a LazyKeysSpec[] as an argument, but the type signature makes it seem it may only receive string[].

