### PR TITLE
fix(ui): reword plugin updates copy

### DIFF
--- a/lua/lazy/manage/checker.lua
+++ b/lua/lazy/manage/checker.lua
@@ -89,8 +89,10 @@ function M.report(notify)
     end
   end
   if #lines > 0 and notify and Config.options.checker.notify and not Config.headless() then
-    table.insert(lines, 1, "# Available Plugin Updates")
+    table.insert(lines, 1, "# Plugin Updates Available")
     Util.info(lines)
+    table.insert(lines, "")
+    table.insert(lines, "Run `:Lazy update` to install")
   end
 end
 

--- a/lua/lazy/manage/checker.lua
+++ b/lua/lazy/manage/checker.lua
@@ -89,7 +89,7 @@ function M.report(notify)
     end
   end
   if #lines > 0 and notify and Config.options.checker.notify and not Config.headless() then
-    table.insert(lines, 1, "# Plugin Updates")
+    table.insert(lines, 1, "# Available Plugin Updates")
     Util.info(lines)
   end
 end

--- a/lua/lazy/manage/checker.lua
+++ b/lua/lazy/manage/checker.lua
@@ -90,9 +90,10 @@ function M.report(notify)
   end
   if #lines > 0 and notify and Config.options.checker.notify and not Config.headless() then
     table.insert(lines, 1, "# Plugin Updates Available")
-    Util.info(lines)
     table.insert(lines, "")
     table.insert(lines, "Run `:Lazy update` to install")
+
+    Util.info(lines)
   end
 end
 


### PR DESCRIPTION
## Description

First of all, thank you for lazy.nvim! It is fast and intuitive, and makes using nvim so much more enjoyable. And the code was easy to read as well.

I'm still new to lazy.nvim and I noticed that it kept printing the following every time I opened nvim, and I couldn't understand why.

```
 # Plugin Updates
- **lazy.nvim**
- **nvim-web-devicons**
- **nvim-tree.lua**
Press ENTER or type command to continue
```

Gemini helped me figure out that these are plugins with available updates, and I thought I could try to make this amazing project even better.

Changes:
* Updated the notification header to `# Updates Available` (or your preferred choice) to clarify the state of the plugins.
* Added a footer: `Run :Lazy update to update` to provide a clear, actionable next step for the user.

## Related Issue(s)
None (UX improvement)

