### PR TITLE
fix(ssh): properly handle GIT_SSH_COMMAND

### DIFF
--- a/lua/lazy/manage/process.lua
+++ b/lua/lazy/manage/process.lua
@@ -125,8 +125,19 @@ end
 
 function Process:env()
   ---@type table<string, string>
+  local SSH_OPTIONS = " -oBatchMode=yes"
+  local GIT_SSH_COMMAND = nil
+  local git_core_ssh = vim.fn.system("git config --get core.sshCommand"):gsub("\n", "")
+
+  if vim.fn.environ().GIT_SSH_COMMAND then
+    GIT_SSH_COMMAND = vim.fn.environ().GIT_SSH_COMMAND
+  elseif git_core_ssh ~= "" then
+    GIT_SSH_COMMAND = git_core_ssh
+  else
+    GIT_SSH_COMMAND = "ssh" --default
+  end
   local env = vim.tbl_extend("force", {
-    GIT_SSH_COMMAND = "ssh -oBatchMode=yes",
+    GIT_SSH_COMMAND = GIT_SSH_COMMAND .. SSH_OPTIONS,
   }, uv.os_environ(), self.opts.env or {})
   env.GIT_DIR = nil
   env.GIT_WORK_TREE = nil


### PR DESCRIPTION
First things first, i really appreciate your work on this excellent plugin. the codebase was intuitive, clean, and modularized enough for me to get to speed fast and start implementing the fix!

## Description
this pull request fixed #2012 
where if the user set a custom git.core.sshCommand lazy.nvim would just ignore it and use the hardcoded value of "ssh" 

what i did:

- 0 separated command arguments into a separate SSH_OPTIONS variable
  
- 1 checked if there is an environment variable that should have the highest precedence, and if there is i would assing it to GIT_SSH_COMMAND

- 2 else if  the user configured a custom git.sshCommand i would acknowledge that and assign it to GIT_SSH_COMMAND

- 3 else GIT_SSH_COMMAND would default to "ssh"

## Related Issue(s)
- Fixed #2012 

## Screenshots

<img width="1736" height="740" alt="fixed_lazy_nvim_2012" src="https://github.com/user-attachments/assets/af4c6e68-bf35-4b55-936b-ff40f44a02bc" />
