### PR TITLE
feat(rockspec): fallback to root manifest when building w/ rockspec

### DIFF
--- a/lua/lazy/pkg/rockspec.lua
+++ b/lua/lazy/pkg/rockspec.lua
@@ -198,6 +198,8 @@ function M.build(task)
     args = {
       "--tree",
       root,
+      "--server",
+      Config.options.rocks.server,
       "--dev",
       "--lua-version",
       "5.1",
@@ -209,6 +211,34 @@ function M.build(task)
     cwd = task.plugin.dir,
     env = env,
   })
+
+  if ok then
+    return
+  end
+
+  task:warn("Failed installing " .. rockspec.package .. " with `luarocks` (dev manifest).")
+  task:warn("\n" .. string.rep("-", 80) .. "\n")
+  task:warn("Trying to build from source with root manifest.")
+
+  -- install failed, so try building from source
+  task:set_level() -- reset level
+  ok = task:spawn(luarocks, {
+    args = {
+      "--tree",
+      root,
+      "--server",
+      Config.options.rocks.server,
+      "--lua-version",
+      "5.1",
+      "make",
+      "--force-fast",
+      "--deps-mode",
+      "one",
+    },
+    cwd = task.plugin.dir,
+    env = env,
+  })
+
   if not ok then
     require("lazy.manage.task.fs").clean.run(task, { rocks_only = true })
   end


### PR DESCRIPTION
## Description

This PR adds the rocks server root manifest as an extra fallback when building plugins with luarocks. If a plugin specifies dependencies that aren't found in the luarocks dev manifest, the local build will fail due to missing dependencies.

For example, `dbus_proxy` isn't present in the luarocks dev manifests (thus doesn't appear in search):
```
lazy.nvim via 🌙 v5.4.8
❯ luarocks --lua-version 5.1 search dbus_proxy

dbus_proxy - Search results for Lua 5.1:
========================================


Rockspecs and source rocks:
---------------------------

dbus_proxy
   0.10.4-1 (rockspec) - https://luarocks.org
   0.10.4-1 (src) - https://luarocks.org
   0.10.3-2 (rockspec) - https://luarocks.org
   0.10.3-2 (src) - https://luarocks.org
   0.10.2-1 (rockspec) - https://luarocks.org
   0.10.2-1 (src) - https://luarocks.org
   0.10.0-1 (rockspec) - https://luarocks.org
   0.10.0-1 (src) - https://luarocks.org
   0.9.0-1 (rockspec) - https://luarocks.org
   0.8.5-1 (rockspec) - https://luarocks.org
   0.8.1-1 (rockspec) - https://luarocks.org
   0.8.0-1 (rockspec) - https://luarocks.org
   0.7.1-1 (rockspec) - https://luarocks.org
   0.7.0-1 (rockspec) - https://luarocks.org

lazy.nvim via 🌙 v5.4.8
❯ luarocks --lua-version 5.1 search --dev dbus_proxy

dbus_proxy - Search results for Lua 5.1:
========================================

```

## Related Issue(s)

Not directly a lazy.nvim issue, but this popped up from an issue with one of my small plugins: https://github.com/cosmicboots/system-theme.nvim/issues/1.
