### PR TITLE
fix(types): fix some type annotations

### DIFF
--- a/lua/lazy/manage/process.lua
+++ b/lua/lazy/manage/process.lua
@@ -5,7 +5,7 @@ local Config = require("lazy.core.config")
 local uv = vim.uv
 
 ---@class ProcessOpts
----@field args string[]
+---@field args? string[]
 ---@field cwd? string
 ---@field on_line? fun(line:string)
 ---@field on_exit? fun(ok:boolean, output:string)

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -44,7 +44,7 @@
 ---@field branch? string
 ---@field tag? string
 ---@field commit? string
----@field version? string|boolean
+---@field version? string|false
 ---@field pin? boolean
 ---@field submodules? boolean Defaults to true
 


### PR DESCRIPTION
## Description

The version type should be `string|false` like in the documentation https://lazy.folke.io/spec#spec-versioning
This fixes a type error in `manage/git.lua`
```lua
  if version then
    local last = Semver.last(M.get_versions(plugin.dir, version)) -- version should only be a string here
```

ProcessOpts args should be optional, since the nil case is already handled in `Process.new` in `manage/process.lua`
This fixes a few places in `manage/git.lua` where args is not supplied
```lua
function M.count(repo, commit1, commit2)
  local lines = Process.exec({ "git", "rev-list", "--count", commit1 .. ".." .. commit2 }, { cwd = repo }) -- warning: args field missing
  return tonumber(lines[1] or "0") or 0
end

function M.age(repo, commit)
  local lines = Process.exec({ "git", "show", "-s", "--format=%cr", "--date=short", commit }, { cwd = repo }) -- warning: args field missing
  return lines[1] or ""
end
```

## Related Issue(s)

## Screenshot
