### PR TITLE
fix(meta): remove usages of vim.opt

### DIFF
--- a/bootstrap.lua
+++ b/bootstrap.lua
@@ -44,7 +44,7 @@ function M.setup()
       os.exit(1)
     end
   end
-  vim.opt.rtp:prepend(lazypath)
+  vim.o.rtp = lazypath .. "," .. vim.o.rtp
 end
 M.setup()
 

--- a/lua/lazy/build.lua
+++ b/lua/lazy/build.lua
@@ -1,4 +1,4 @@
-vim.opt.rtp:append(".")
+vim.o.rtp = vim.o.rtp .. ",."
 local Rocks = require("lazy.pkg.rockspec")
 local Semver = require("lazy.manage.semver")
 local Util = require("lazy.util")

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -302,20 +302,18 @@ function M.setup(opts)
   lib = vim.uv.fs_stat(lib .. "64") and (lib .. "64") or lib
   lib = lib .. "/nvim"
   if M.options.performance.rtp.reset then
-    ---@type vim.Option
-    vim.opt.rtp = {
-      vim.fn.stdpath("config"),
-      vim.fn.stdpath("data") .. "/site",
-      M.me,
-      vim.env.VIMRUNTIME,
-      lib,
-      vim.fn.stdpath("config") .. "/after",
-    }
+    -- stylua: ignore
+    vim.o.rtp = vim.fn.stdpath("config") .. ","
+      .. vim.fn.stdpath("data") .. "/site" .. ","
+      .. M.me .. ","
+      .. vim.env.VIMRUNTIME .. ","
+      .. lib .. ","
+      .. vim.fn.stdpath("config") .. "/after"
   end
   for _, path in ipairs(M.options.performance.rtp.paths) do
-    vim.opt.rtp:append(path)
+    vim.o.rtp = vim.o.rtp .. "," .. path
   end
-  vim.opt.rtp:append(M.options.readme.root)
+  vim.o.rtp = vim.o.rtp .. "," .. M.options.readme.root
 
   -- disable plugin loading since we do all of that ourselves
   vim.go.loadplugins = false

--- a/lua/lazy/core/loader.lua
+++ b/lua/lazy/core/loader.lua
@@ -104,7 +104,7 @@ function M.startup()
   M.source(vim.env.VIMRUNTIME .. "/filetype.lua")
 
   -- backup original rtp
-  local rtp = vim.opt.rtp:get() --[[@as string[] ]]
+  local rtp = vim.iter(vim.o.rtp:gmatch("([^,]+),")):totable() --[[@as string[] ]]
 
   -- 1. run plugin init
   Util.track({ start = "init" })
@@ -144,7 +144,7 @@ function M.startup()
   -- 4. load after plugins
   Util.track({ start = "after" })
   for _, path in
-    ipairs(vim.opt.rtp:get() --[[@as string[] ]])
+    ipairs(vim.iter(vim.o.rtp:gmatch("([^,]+),")):totable() --[[@as string[] ]])
   do
     if path:find("after/?$") then
       M.source_runtime(path, "plugin")
@@ -488,8 +488,9 @@ function M.add_to_rtp(plugin)
     table.insert(rtp, idx_after or (#rtp + 1), after)
   end
 
-  ---@type vim.Option
-  vim.opt.rtp = rtp
+  vim.o.rtp = vim.iter(rtp):fold("", function(s, p)
+    return s .. (#s > 0 and "," or "") .. p
+  end)
 end
 
 ---@param plugin LazyPlugin

--- a/lua/lazy/health.lua
+++ b/lua/lazy/health.lua
@@ -71,7 +71,8 @@ function M.check()
 
   M.have("git")
 
-  local sites = vim.opt.packpath:get()
+  -- TODO: some paths might have ',': what pattern to match them?
+  local sites = vim.iter(vim.o.packpath:gmatch("([^,]+),")):totable() --[[@as string[] ]]
   local default_site = vim.fn.stdpath("data") .. "/site"
   if not vim.tbl_contains(sites, default_site) then
     sites[#sites + 1] = default_site
@@ -90,8 +91,11 @@ function M.check()
     ok("no existing packages found by other package managers")
   end
 
+  -- TODO: same problem as 'sites' above.
+  local rtp_tbl = vim.iter(vim.o.rtp:gmatch("([^,]+),")):totable() --[[@as string[] ]]
+
   for _, name in ipairs({ "packer", "plugged", "paq", "pckr", "mini.deps" }) do
-    for _, path in ipairs(vim.opt.rtp:get()) do
+    for _, path in ipairs(rtp_tbl) do
       if path:find(name, 1, true) then
         error("Found paths on the rtp from another plugin manager `" .. name .. "`")
         break

--- a/lua/lazy/init.lua
+++ b/lua/lazy/init.lua
@@ -132,7 +132,7 @@ function M.bootstrap()
       lazypath,
     })
   end
-  vim.opt.rtp:prepend(lazypath)
+  vim.o.rtp = lazypath .. "," .. vim.o.rtp
 end
 
 ---@return LazyPlugin[]

--- a/tests/core/util_spec.lua
+++ b/tests/core/util_spec.lua
@@ -3,10 +3,9 @@ local Helpers = require("tests.helpers")
 local Util = require("lazy.util")
 
 describe("util", function()
-  local rtp = vim.opt.rtp:get()
+  local rtp = vim.o.rtp
   before_each(function()
-    ---@type vim.Option
-    vim.opt.rtp = rtp
+    vim.o.rtp = rtp
     for k, v in pairs(package.loaded) do
       if k:find("^foobar") then
         package.loaded[k] = nil
@@ -17,7 +16,7 @@ describe("util", function()
   end)
 
   it("lsmod lists all mods in dir", function()
-    vim.opt.rtp:append(Helpers.path(""))
+    vim.o.rtp = vim.o.rtp .. "," .. Helpers.path("")
     local tests = {
       {
         root = "lua/foo",
@@ -79,7 +78,7 @@ describe("util", function()
 
   it("find the correct root with dels", function()
     Cache.reset()
-    vim.opt.rtp:append(Helpers.path("old"))
+    vim.o.rtp = vim.o.rtp .. "," .. Helpers.path("old")
     Helpers.fs_create({ "old/lua/foobar/init.lua" })
     local root = Util.find_root("foobar")
     assert(root, "foobar root not found")
@@ -88,8 +87,8 @@ describe("util", function()
     Helpers.fs_rm("old")
     assert(not vim.uv.fs_stat(Helpers.path("old/lua/foobar")), "old/lua/foobar should not exist")
 
-    -- vim.opt.rtp = rtp
-    vim.opt.rtp:append(Helpers.path("new"))
+    -- vim.o.rtp = rtp
+    vim.o.rtp = vim.o.rtp .. "," .. Helpers.path("new")
     Helpers.fs_create({ "new/lua/foobar/init.lua" })
     root = Util.find_root("foobar")
     assert(root, "foobar root not found")

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -2,7 +2,7 @@
 
 vim.env.LAZY_STDPATH = ".tests"
 
-vim.opt.rtp:prepend(".")
+vim.o.rtp = ".," .. vim.o.rtp
 
 -- Setup lazy.nvim
 require("lazy.minit").setup({


### PR DESCRIPTION
The `vim.opt` interface is going away in favor of `vim.o`.

This PR removes any reference to this interface, and replaces the few places where it was used as a Lua-first interface with calls to `vim.iter` which attempt to provide the same behaviour.

This [issue on github/neovim/neovim](https://github.com/neovim/neovim/issues/20107) tracks the deprecation of `vim.opt`, and some of the plugins I use on a daily basis have been preparing for it. Thought I'd do the same for `lazy.nvim`.