### PR TITLE
feat(git): allow version policy functions

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -354,24 +354,24 @@ Refer to the Lazy Loading <./lazy_loading.md> section for more information.
 
 SPEC VERSIONING                   *lazy.nvim-🔌-plugin-spec-spec-versioning*
 
-  ------------------------------------------------------------------------------
-  Property     Type                 Description
-  ------------ -------------------- --------------------------------------------
-  branch       string?              Branch of the repository
+  ------------------------------------------------------------------------------------------------------------------
+  Property     Type                                          Description
+  ------------ --------------------------------------------- -------------------------------------------------------
+  branch       string?                                       Branch of the repository
 
-  tag          string?              Tag of the repository
+  tag          string?                                       Tag of the repository
 
-  commit       string?              Commit of the repository
+  commit       string?                                       Commit of the repository
 
-  version      string? or false to  Version to use from the repository. Full
-               override the default Semver ranges are supported
+  version      string? or false to override the default or   Version to use from the repository. Full Semver ranges
+               fun(repo:string, branch:string):GitInfo       are supported. Use a function to implement a version
+                                                             policy.
 
-  pin          boolean?             When true, this plugin will not be included
-                                    in updates
+  pin          boolean?                                      When true, this plugin will not be included in updates
 
-  submodules   boolean?             When false, git submodules will not be
-                                    fetched. Defaults to true
-  ------------------------------------------------------------------------------
+  submodules   boolean?                                      When false, git submodules will not be fetched.
+                                                             Defaults to true
+  ------------------------------------------------------------------------------------------------------------------
 Refer to the Versioning <./versioning.md> section for more information.
 
 
@@ -624,6 +624,7 @@ will be added to the plugin’s spec.
         -- have outdated releases, which may break your Neovim install.
         version = nil, -- always use the latest git commit
         -- version = "*", -- try installing the latest stable version for plugins that support semver
+        ---@type string|fun(repo:string, branch:string):GitInfo|nil
         -- default `cond` you can use to globally disable a lot of plugins
         -- when running inside vscode for example
         cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil

--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -622,9 +622,9 @@ will be added to the plugin’s spec.
         lazy = false, -- should plugins be lazy-loaded?
         -- It's recommended to leave version=false for now, since a lot the plugin that support versioning,
         -- have outdated releases, which may break your Neovim install.
+        ---@type string|boolean|fun(repo:string, branch:string):GitInfo|nil
         version = nil, -- always use the latest git commit
         -- version = "*", -- try installing the latest stable version for plugins that support semver
-        ---@type string|fun(repo:string, branch:string):GitInfo|nil
         -- default `cond` you can use to globally disable a lot of plugins
         -- when running inside vscode for example
         cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -12,6 +12,7 @@ M.defaults = {
     lazy = false, -- should plugins be lazy-loaded?
     -- It's recommended to leave version=false for now, since a lot the plugin that support versioning,
     -- have outdated releases, which may break your Neovim install.
+    ---@type string|boolean|fun(repo:string, branch:string):GitInfo|nil
     version = nil, -- always use the latest git commit
     -- version = "*", -- try installing the latest stable version for plugins that support semver
     -- default `cond` you can use to globally disable a lot of plugins

--- a/lua/lazy/manage/git.lua
+++ b/lua/lazy/manage/git.lua
@@ -140,6 +140,9 @@ function M.get_target(plugin)
 
   local version = (plugin.version == nil and plugin.branch == nil) and Config.options.defaults.version or plugin.version
   if version then
+    if type(version) == "function" then
+      return version(plugin.dir, branch)
+    end
     local last = Semver.last(M.get_versions(plugin.dir, version))
     if last then
       return {

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -44,7 +44,7 @@
 ---@field branch? string
 ---@field tag? string
 ---@field commit? string
----@field version? string|boolean
+---@field version? string|boolean|fun(repo:string, branch:string):GitInfo
 ---@field pin? boolean
 ---@field submodules? boolean Defaults to true
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
With this pull request, it is possible to assign a function to the `version` key in the configuration or in a spec to implement more complex version policies.

### Examples of problems it can solve
#### Example 1
The user want `lazy.nvim` to respect a cooldown period (e.g.: 21 days) for all packages. It is part of his strategy to mitigate the threat of supply chain attacks. Here is a simple way to achieve this:

Add this function somewhere in the personal configuration files:
```lua
function version_policy_commit_cooldown(repo, branch, date)
  local output = vim.fn.system({
    "git",
    string.format([[--git-dir=%s/.git]], repo),
    "rev-list", branch, "-1",
    string.format([[--before=%s]], date) })
  return { branch = branch, commit = vim.split(output, "\n")[1] }
end
```
Note: Inspired by #2135

Assign to the `defaults` `version` key the following version policy function:
```lua
...
-- Setup lazy.nvim
require("lazy").setup({
  defaults = {
    version = function(repo, branch)
      return version_policy_commit_cooldown(repo, branch, "21 days ago")
    end
  },
...
```

#### Example 2
The user has a more complex version policy for a specific plugin. He wants:
- To preserve the cooldown period of 21 days
- To select a package that has a semver version tag with the patch number not 0
- If there is no version tag with a patch number not 0, choose the newest version tag
- If there is no version tag, pick the newest commit

Here is a way to achieve this:

Add these functions somewhere in the personal configuration files:
```lua
function get_commit_refs_list(repo, branch, before_date, after_date)
  local command = {
    "git",
    string.format([[--git-dir=%s/.git]], repo),
    "log",
    branch,
    "--format=%H\t%(decorate:tag=tag:,separator= ,prefix=,suffix=)",
  }
  if before_date ~= nil then
    table.insert(command, 5, string.format([[--before=%s]], before_date))
  end
  if after_date ~= nil then
    table.insert(command, 5, string.format([[--after=%s]], after_date))
  end
  local stdout = vim.fn.system(command)
  stdout = string.gsub(stdout, '^(.*)%s$', '%1')
  local output = {}
  local refs = {}
  local sections = {}
  for i, line in ipairs(vim.split(stdout, "\n")) do
    refs = {}
    sections = vim.split(line, "\t")
    for j, ref in ipairs(vim.split(sections[2], " ")) do
      refs[j] = ref
    end
    output[i] = { commit = sections[1], refs = refs }
  end
  return output
end

function get_release_commit_tag(commit_refs_list, pattern)
  local tag = nil
  for _, commit_data in ipairs(commit_refs_list) do
    for _, ref in ipairs(commit_data.refs) do
      if string.sub(ref, 1, 4) == "tag:" then
        tag = string.sub(ref, 5, -1)
        if string.match(tag, pattern) then
          return { commit = commit_data.commit, tag = tag }
        end
      end
    end
  end
  return nil
end
```

Assign to the `spec` `version` key the following version policy function:
```lua
...
require("lazy").setup({
...
  spec = {
    -- add your plugins here
    {
      "nvim-telescope/telescope.nvim",
      version = function(repo, branch)
        local commit_refs_list = get_commit_refs_list(repo, branch, "21 days ago", nil)
        local commit_tag =
          get_release_commit_tag(commit_refs_list, "^v%d+%.%d+%.[1-9]")
          or get_release_commit_tag(commit_refs_list, "^v%d+")
          or { commit = commit_refs_list[1].commit, tag = nil }
        if commit_tag.tag == nil then
          return { branch = branch, commit = commit_tag.commit }
        end
        return {
          branch = branch,
          version = string.sub(commit_tag.tag, 2, -1),
          tag = commit_tag.tag,
          commit = commit_tag.commit,
        }
      end,
    },
...
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #2141
- Fixes #2081

## Screenshots

<!-- Add screenshots of the changes if applicable. -->