### PR TITLE
feat(config): add minimum_release_age option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - 🔒 Lockfile `lazy-lock.json` to keep track of installed plugins
 - 🔎 Automatically check for updates
 - 📋 Commit, branch, tag, version, and full [Semver](https://devhints.io/semver) support
+- 🛡️ Optional `minimum_release_age` to delay freshly published commits/tags (supply-chain safety, inspired by pnpm/mise/Renovate/Dependabot)
 - 📈 Statusline component to see the number of pending updates
 - 🎨 Automatically lazy-loads colorschemes
 

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -17,6 +17,30 @@ M.defaults = {
     -- default `cond` you can use to globally disable a lot of plugins
     -- when running inside vscode for example
     cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil
+    -- Minimum age a commit or semver tag must have before it is considered
+    -- for updates. Mitigates supply-chain attacks by waiting until a ref has
+    -- been published for the specified period before adopting it. Accepts an
+    -- integer (seconds) or a single-unit string like "30m", "24h", "7d",
+    -- "2w", "1y". Combined forms ("7d12h", "1d 2h") are not supported --
+    -- use a single unit. Set to nil (default) to disable globally.
+    --
+    -- Per-plugin overrides are accepted on each spec entry:
+    --   minimum_release_age = "..."  -- set a custom value for this plugin
+    --   minimum_release_age = false  -- force-disable for this plugin even
+    --                                -- when a global default is set
+    -- (Setting `false` globally is equivalent to nil.)
+    --
+    -- Explicit `commit=`/`tag=` pins and `pin = true` plugins are not
+    -- affected.
+    minimum_release_age = nil, ---@type string|number|nil
+    -- When true, allow :Lazy update to roll back to an older commit that
+    -- satisfies minimum_release_age, even if the currently installed commit
+    -- is newer. When false (default), an already-installed plugin keeps its
+    -- current commit when it is past what minimum_release_age would otherwise
+    -- pick; the newer commit is still surfaced via the
+    -- "Pending (minimum_release_age = ...)" UI section. Has no effect on
+    -- fresh installs, which always honor minimum_release_age.
+    minimum_release_age_downgrade = false, ---@type boolean
   },
   -- leave nil when passing the spec as the first argument to setup()
   spec = nil, ---@type LazySpec

--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -319,6 +319,53 @@ function M.find_local_spec()
   end
 end
 
+--- Reads the origin URL of the lazy.nvim clone that the running process is
+--- loaded from. Returns nil when the directory is not a git checkout or the
+--- file cannot be read (e.g. an immutable /nix/store path).
+---@return string?
+local function read_self_origin()
+  local f = io.open(Config.me .. "/.git/config", "r")
+  if not f then
+    return nil
+  end
+  local config = f:read("*a")
+  f:close()
+  local in_origin = false
+  for line in config:gmatch("[^\n]+") do
+    local section = line:match("^%s*%[(.+)%]%s*$")
+    if section then
+      in_origin = section:match('^remote%s+"origin"$') ~= nil
+    elseif in_origin then
+      local key, value = line:match("^%s*(%S+)%s*=%s*(.-)%s*$")
+      if key == "url" then
+        return value
+      end
+    end
+  end
+  return nil
+end
+
+--- Builds the spec entry that lazy.nvim auto-injects for itself, so that
+--- :Lazy can manage updates to the very clone it is running from. Forks
+--- (and any non-folke clones) work out of the box without touching this
+--- file.
+---@return LazyPluginSpec
+local function self_spec()
+  local origin = read_self_origin()
+  if origin and origin ~= "" then
+    -- Prefer the familiar "owner/repo" GitHub shorthand when possible.
+    local short = origin:match("github%.com[:/](.+)$")
+    if short then
+      short = short:gsub("%.git$", "")
+      if short:match("^[^/]+/[^/]+$") then
+        return { short }
+      end
+    end
+    return { url = origin, name = "lazy.nvim" }
+  end
+  return { "folke/lazy.nvim" }
+end
+
 function M.load()
   M.loading = true
   -- load specs
@@ -330,7 +377,7 @@ function M.load()
     vim.deepcopy(Config.options.spec),
   }
   specs[#specs + 1] = M.find_local_spec()
-  specs[#specs + 1] = { "folke/lazy.nvim" }
+  specs[#specs + 1] = self_spec()
 
   Config.spec:parse(specs)
 

--- a/lua/lazy/manage/checker.lua
+++ b/lua/lazy/manage/checker.lua
@@ -39,10 +39,15 @@ function M.fast_check(opts)
     -- only if local is behind upstream (if the git log task gives no output)
     if plugin._.installed and not (plugin.pin or plugin._.is_local) then
       plugin._.updates = nil
+      plugin._.pending_age = nil
       local info = Git.info(plugin.dir)
       local ok, target = pcall(Git.get_target, plugin)
-      if ok and info and target and not Git.eq(info, target) then
+      local raw_ok, raw_target = pcall(Git.get_target, plugin, true)
+      if ok and info and target and not Git.eq(info, target) and not Git.is_downgrade(plugin, info, target) then
         plugin._.updates = { from = info, to = target }
+      end
+      if raw_ok and info then
+        plugin._.pending_age = Git.detect_pending_age(plugin, info, target, raw_target)
       end
     end
   end

--- a/lua/lazy/manage/git.lua
+++ b/lua/lazy/manage/git.lua
@@ -114,8 +114,170 @@ function M.get_commit(repo, branch, origin)
 end
 
 ---@param plugin LazyPlugin
+---@return integer? seconds, or nil when disabled for this plugin
+function M.get_minimum_release_age(plugin)
+  local value = plugin.minimum_release_age
+  if value == nil then
+    value = Config.options.defaults.minimum_release_age
+  end
+  return Util.parse_age(value)
+end
+
+---@param plugin LazyPlugin
+---@return boolean true when downgrades to an older mature commit are allowed
+function M.allow_downgrade(plugin)
+  local v = plugin.minimum_release_age_downgrade
+  if v == nil then
+    v = Config.options.defaults.minimum_release_age_downgrade
+  end
+  return v == true
+end
+
+--- Returns the timestamp that the age filter uses for a GitInfo target.
+--- For tag targets this is the tag's creatordate (matches get_target's
+--- semver-path filter); otherwise it falls back to the commit's committer
+--- date. Returns nil when neither can be resolved.
+---@param repo string
+---@param target GitInfo
+---@return integer?
+function M.target_time(repo, target)
+  if target.tag then
+    local tag_times = M.get_tag_times(repo)
+    local t = tag_times[target.tag]
+    if t then
+      return t
+    end
+  end
+  if target.commit then
+    return M.commit_time(repo, target.commit)
+  end
+  return nil
+end
+
+---@param repo string
+---@param ancestor string commit SHA that should be the ancestor
+---@param descendant string commit SHA that should be the descendant
+---@return boolean true if `ancestor` is an ancestor of `descendant`
+function M.is_ancestor(repo, ancestor, descendant)
+  local ok, code = pcall(function()
+    local _, c = Process.exec({ "git", "merge-base", "--is-ancestor", ancestor, descendant }, { cwd = repo })
+    return c
+  end)
+  return ok and code == 0
+end
+
+--- Returns true when applying `target` would roll `info` back to one of its
+--- ancestors (i.e. info is already newer than what minimum_release_age would
+--- pick) and the active policy disallows that downgrade. Fresh installs
+--- (`plugin._.cloned == true`) are exempt and always return false so the
+--- initial checkout honors the age constraint.
+---@param plugin LazyPlugin
+---@param info GitInfo
+---@param target GitInfo
+---@return boolean
+function M.is_downgrade(plugin, info, target)
+  if M.allow_downgrade(plugin) then
+    return false
+  end
+  if plugin._.cloned then
+    return false
+  end
+  if not (info.commit and target.commit) then
+    return false
+  end
+  if M.eq(info, target) then
+    return false
+  end
+  return M.is_ancestor(plugin.dir, target.commit, info.commit)
+end
+
+--- Builds the `pending_age` state when `raw_target` (the age-ignoring target)
+--- differs from what is effectively being applied. Returns nil when nothing
+--- is being held back.
+---@param plugin LazyPlugin
+---@param info GitInfo
+---@param target GitInfo?
+---@param raw_target GitInfo?
+---@return {from:GitInfo, to:GitInfo, eligible_at:integer?}?
+function M.detect_pending_age(plugin, info, target, raw_target)
+  if not (raw_target and info) then
+    return nil
+  end
+  local effective = target or info
+  if M.eq(effective, raw_target) then
+    return nil
+  end
+  local age = M.get_minimum_release_age(plugin)
+  local source_time = M.target_time(plugin.dir, raw_target)
+  return {
+    from = effective,
+    to = raw_target,
+    eligible_at = source_time and age and (source_time + age) or nil,
+  }
+end
+
+---@param repo string
+---@return table<string, integer>
+function M.get_tag_times(repo)
+  ---@type table<string, integer>
+  local ret = {}
+  local ok, lines = pcall(function()
+    return Process.exec(
+      { "git", "for-each-ref", "--format=%(refname:strip=2) %(creatordate:unix)", "refs/tags" },
+      { cwd = repo }
+    )
+  end)
+  if not ok then
+    return ret
+  end
+  for _, line in ipairs(lines) do
+    local tag, ts = line:match("^(.+) (%d+)$")
+    if tag then
+      ret[tag] = tonumber(ts)
+    end
+  end
+  return ret
+end
+
+---@param repo string
+---@param ref string
+---@return integer?
+function M.commit_time(repo, ref)
+  local ok, lines = pcall(function()
+    return Process.exec({ "git", "show", "-s", "--format=%ct", ref }, { cwd = repo })
+  end)
+  if not ok then
+    return nil
+  end
+  return tonumber(lines[1])
+end
+
+---@param repo string
+---@param branch string
+---@param cutoff integer Unix timestamp; commit must be at or before this time
+---@return string?
+function M.last_commit_before(repo, branch, cutoff)
+  local ok, lines = pcall(function()
+    return Process.exec({
+      "git",
+      "log",
+      "-1",
+      "--format=%H",
+      "--before=@" .. cutoff,
+      "refs/remotes/origin/" .. branch,
+    }, { cwd = repo })
+  end)
+  if not ok then
+    return nil
+  end
+  local commit = lines[1]
+  return commit and commit ~= "" and commit or nil
+end
+
+---@param plugin LazyPlugin
+---@param ignore_age? boolean If true, bypass minimum_release_age filtering.
 ---@return GitInfo?
-function M.get_target(plugin)
+function M.get_target(plugin, ignore_age)
   if plugin._.is_local then
     local info = M.info(plugin.dir)
     local branch = assert(info and info.branch or M.get_branch(plugin))
@@ -138,9 +300,25 @@ function M.get_target(plugin)
     }
   end
 
+  local age = not ignore_age and M.get_minimum_release_age(plugin) or nil
+  local cutoff = age and (os.time() - age) or nil
+
   local version = (plugin.version == nil and plugin.branch == nil) and Config.options.defaults.version or plugin.version
   if version then
-    local last = Semver.last(M.get_versions(plugin.dir, version))
+    local versions = M.get_versions(plugin.dir, version)
+    if cutoff and #versions > 0 then
+      local tag_times = M.get_tag_times(plugin.dir)
+      local filtered = vim.tbl_filter(function(v)
+        local t = tag_times[v.tag]
+        return t ~= nil and t <= cutoff
+      end, versions)
+      -- An age constraint that rejects every candidate tag means "wait".
+      if #filtered == 0 then
+        return nil
+      end
+      versions = filtered
+    end
+    local last = Semver.last(versions)
     if last then
       return {
         branch = branch,
@@ -150,6 +328,15 @@ function M.get_target(plugin)
       }
     end
   end
+
+  if cutoff then
+    local commit = M.last_commit_before(plugin.dir, branch, cutoff)
+    if commit then
+      return { branch = branch, commit = commit }
+    end
+    return nil
+  end
+
   return { branch = branch, commit = M.get_commit(plugin.dir, branch, true) }
 end
 

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -84,17 +84,27 @@ M.log = {
       table.insert(args, self.plugin._.updated.from .. ".." .. (self.plugin._.updated.to or "HEAD"))
     elseif opts.check then
       info = assert(Git.info(self.plugin.dir))
-      target = assert(Git.get_target(self.plugin))
+      target = Git.get_target(self.plugin)
+      local raw_target = Git.get_target(self.plugin, true)
+      self.plugin._.pending_age = Git.detect_pending_age(self.plugin, info, target, raw_target)
+      if not target then
+        -- minimum_release_age is blocking every candidate; fall back to info
+        -- so the log range becomes a no-op.
+        target = info
+      elseif Git.is_downgrade(self.plugin, info, target) then
+        -- info is already past what minimum_release_age would pick; don't
+        -- treat that as an update.
+        target = info
+      end
       if not target.commit then
         for k, v in pairs(target) do
           error(k .. " '" .. v .. "' not found")
         end
         error("no target commit found")
       end
-      assert(target.commit, self.plugin.name .. " " .. target.branch)
       if not self.plugin._.is_local then
         if Git.eq(info, target) then
-          if Config.options.checker.check_pinned then
+          if Config.options.checker.check_pinned and target.branch then
             local last_commit = Git.get_commit(self.plugin.dir, target.branch, true)
             if not Git.eq(info, { commit = last_commit }) then
               self.plugin._.outdated = true
@@ -317,7 +327,27 @@ M.checkout = {
   run = function(self, opts)
     throttle.wait()
     local info = assert(Git.info(self.plugin.dir))
-    local target = assert(Git.get_target(self.plugin))
+    local target = Git.get_target(self.plugin)
+
+    if not target then
+      if self.plugin._.cloned and Git.get_target(self.plugin, true) then
+        -- Fresh install where minimum_release_age blocks every candidate.
+        -- Refusing to silently land on whatever the clone happens to point
+        -- at (e.g. HEAD), since that defeats the constraint the user set.
+        error(
+          "minimum_release_age has no eligible commit/tag yet for "
+            .. self.plugin.name
+            .. "; relax the constraint or retry once a candidate matures"
+        )
+      end
+      -- For an already-installed plugin, keep the current commit so the
+      -- checkout is a no-op until the next mature candidate is reached.
+      target = info
+    elseif Git.is_downgrade(self.plugin, info, target) then
+      -- info is already past what minimum_release_age would pick; don't
+      -- downgrade it unless explicitly opted in.
+      target = info
+    end
 
     -- if the plugin is pinned and we did not just clone it,
     -- then don't update

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -21,6 +21,7 @@
 ---@field tasks? LazyTask[]
 ---@field updated? {from:string, to:string}
 ---@field updates? {from:GitInfo, to:GitInfo}
+---@field pending_age? {from:GitInfo, to:GitInfo, eligible_at?:integer} Update available but blocked by minimum_release_age; eligible_at is the unix timestamp when `to` becomes acceptable.
 ---@field last_check? number
 ---@field working? boolean
 ---@field pkg? LazyPkg
@@ -47,6 +48,8 @@
 ---@field version? string|boolean
 ---@field pin? boolean
 ---@field submodules? boolean Defaults to true
+---@field minimum_release_age? string|number|false Override the global minimum_release_age. Use false to disable for this plugin.
+---@field minimum_release_age_downgrade? boolean Override the global minimum_release_age_downgrade. Set true to permit downgrading this plugin to a mature commit.
 
 ---@class LazyPluginBase
 ---@field [1] string?

--- a/lua/lazy/util.lua
+++ b/lua/lazy/util.lua
@@ -274,6 +274,65 @@ function M.dump(value)
   return table.concat(result, "")
 end
 
+M._age_units = {
+  s = 1,
+  m = 60,
+  h = 60 * 60,
+  d = 24 * 60 * 60,
+  w = 7 * 24 * 60 * 60,
+  y = 365 * 24 * 60 * 60,
+}
+
+--- Parses a minimum-release-age value into seconds.
+--- Accepts a non-negative integer (seconds) or a string of the form "<int><unit>",
+--- where unit is exactly one of s/m/h/d/w/y. Only one unit is allowed per value:
+--- "7d12h" or "1d 2h" are NOT supported; combine into a single value like "180h".
+--- Returns nil for false/nil/invalid input.
+---@param value string|number|false|nil
+---@return integer?
+function M.parse_age(value)
+  if value == nil or value == false then
+    return nil
+  end
+  if type(value) == "number" then
+    if value < 0 or value ~= math.floor(value) then
+      M.warn("Invalid minimum_release_age: " .. tostring(value))
+      return nil
+    end
+    return value > 0 and value or nil
+  end
+  if type(value) == "string" then
+    local n, unit = value:match("^(%d+)%s*([smhdwy])$")
+    if n and unit then
+      local seconds = tonumber(n) * M._age_units[unit]
+      return seconds > 0 and seconds or nil
+    end
+  end
+  M.warn("Invalid minimum_release_age: " .. vim.inspect(value))
+  return nil
+end
+
+--- Formats a positive duration in seconds as a coarse human label.
+--- Returns "Nd"/"Nh"/"Nm"/"Ns" picking the largest fitting unit. Values at
+--- or below zero return "now".
+---@param seconds integer
+---@return string
+function M.format_duration(seconds)
+  if seconds <= 0 then
+    return "now"
+  end
+  if seconds >= M._age_units.d then
+    return math.floor(seconds / M._age_units.d) .. "d"
+  end
+  if seconds >= M._age_units.h then
+    return math.floor(seconds / M._age_units.h) .. "h"
+  end
+  if seconds >= M._age_units.m then
+    return math.floor(seconds / M._age_units.m) .. "m"
+  end
+  return seconds .. "s"
+end
+
 ---@generic V
 ---@param t table<string, V>
 ---@param fn fun(key:string, value:V)

--- a/lua/lazy/view/render.lua
+++ b/lua/lazy/view/render.lua
@@ -279,7 +279,8 @@ function M:section(section)
     return a.name:lower() < b.name:lower()
   end)
   if count > 0 then
-    self:append(section.title, "LazyH2"):append(" (" .. count .. ")", "LazyComment"):nl()
+    local title = type(section.title) == "function" and section.title() or section.title
+    self:append(title, "LazyH2"):append(" (" .. count .. ")", "LazyComment"):nl()
     for _, plugin in ipairs(section_plugins) do
       self:plugin(plugin)
     end
@@ -437,6 +438,21 @@ function M:diagnostics(plugin)
         message = "updates available",
       })
     end
+  elseif plugin._.pending_age then
+    local pa = plugin._.pending_age
+    local label
+    if pa.to.version then
+      label = "version " .. tostring(pa.to.version)
+    elseif pa.to.commit then
+      label = "commit " .. pa.to.commit:sub(1, 7)
+    else
+      label = "update"
+    end
+    if pa.eligible_at then
+      local remaining = pa.eligible_at - os.time()
+      label = label .. " (available in " .. require("lazy.util").format_duration(remaining) .. ")"
+    end
+    self:diagnostic({ message = label })
   end
 end
 

--- a/lua/lazy/view/sections.lua
+++ b/lua/lazy/view/sections.lua
@@ -10,7 +10,21 @@ local function has_task(plugin, filter)
   end
 end
 
----@alias LazySection {title:string, filter:fun(plugin:LazyPlugin):boolean?}
+---@alias LazySection {title:string|fun():string, filter:fun(plugin:LazyPlugin):boolean?}
+
+---@return string
+local function pending_age_title()
+  local Config = require("lazy.core.config")
+  local v = Config.options and Config.options.defaults and Config.options.defaults.minimum_release_age
+  -- Treat nil and false identically: both mean "no global constraint", so the
+  -- Pending section is showing only because of per-plugin overrides and the
+  -- header has no single value to display.
+  if v == nil or v == false then
+    return "Pending (minimum_release_age)"
+  end
+  local rendered = type(v) == "string" and ('"' .. v .. '"') or tostring(v)
+  return "Pending (minimum_release_age = " .. rendered .. ")"
+end
 
 ---@type LazySection[]
 return {
@@ -72,6 +86,13 @@ return {
       return plugin._.updates ~= nil
     end,
     title = "Updates",
+  },
+  {
+    ---@param plugin LazyPlugin
+    filter = function(plugin)
+      return plugin._.pending_age ~= nil
+    end,
+    title = pending_age_title,
   },
   {
     filter = function(plugin)

--- a/tests/core/util_spec.lua
+++ b/tests/core/util_spec.lua
@@ -2,6 +2,40 @@ local Cache = require("lazy.core.cache")
 local Helpers = require("tests.helpers")
 local Util = require("lazy.util")
 
+describe("util.parse_age", function()
+  local cases = {
+    { input = nil, expected = nil },
+    { input = false, expected = nil },
+    { input = 0, expected = nil },
+    { input = 60, expected = 60 },
+    { input = 3600, expected = 3600 },
+    { input = "0d", expected = nil },
+    { input = "30s", expected = 30 },
+    { input = "30m", expected = 30 * 60 },
+    { input = "24h", expected = 24 * 60 * 60 },
+    { input = "7d", expected = 7 * 24 * 60 * 60 },
+    { input = "2w", expected = 14 * 24 * 60 * 60 },
+    { input = "1y", expected = 365 * 24 * 60 * 60 },
+  }
+  for _, case in ipairs(cases) do
+    it("parses " .. vim.inspect(case.input), function()
+      assert.equal(case.expected, Util.parse_age(case.input))
+    end)
+  end
+
+  it("rejects invalid strings", function()
+    -- silence the warn notification during the test
+    local orig = vim.notify
+    vim.notify = function() end
+    assert.equal(nil, Util.parse_age("foo"))
+    assert.equal(nil, Util.parse_age("7days"))
+    assert.equal(nil, Util.parse_age("d"))
+    assert.equal(nil, Util.parse_age(-5))
+    assert.equal(nil, Util.parse_age(1.5))
+    vim.notify = orig
+  end)
+end)
+
 describe("util", function()
   local rtp = vim.opt.rtp:get()
   before_each(function()


### PR DESCRIPTION
## Description

Add a `minimum_release_age` option that mitigates supply-chain attacks by ignoring commits and tags that have not been published long enough. Modeled on pnpm's [minimumReleaseAge](https://pnpm.io/settings#minimumreleaseage), mise's [minimum_release_age](https://mise.jdx.dev/configuration/settings.html#minimum_release_age), Renovate, and Dependabot's `cooldown`. Default is `nil`, so this is fully opt-in with no behavior change for existing users.

### Usage

```lua
require("lazy").setup(spec, {
  defaults = {
    minimum_release_age = "7d", -- wait 7 days before adopting new commits/tags
  },
})
```

Accepts a non-negative integer (seconds) or a single-unit duration string (`"30m"`, `"24h"`, `"7d"`, `"2w"`, `"1y"`). Combined forms (`"7d12h"`) are not supported -- use a single unit.

Per-plugin overrides are accepted on each spec entry:

```lua
{ "owner/risky",    minimum_release_age = "30d" },   -- stricter for this one
{ "owner/critical", minimum_release_age = false },   -- disable for this one
```

### Value semantics

How each value is interpreted depending on where it is set:

| Value | At `defaults` (global) | At spec entry (per-plugin) |
|---|---|---|
| `nil` | feature disabled (default) | inherit global |
| `false` | equivalent to `nil` | force-disable for this plugin only |
| integer (seconds) | apply this constraint | override global for this plugin |
| `"30m"`/`"24h"`/`"7d"`/`"2w"`/`"1y"` | apply this constraint | override global for this plugin |
| anything else (`"7d12h"`, `"foo"`, …) | parsed as invalid → warning, treated as `nil` | same |

### Scope

Applies only to fuzzy resolution paths. Explicit pins and `pin = true` plugins are exempt, matching Renovate's pin-exemption semantics:

| Spec form | Affected by `minimum_release_age`? |
|---|---|
| `{ "owner/repo" }` (default-branch following) | yes |
| `{ "owner/repo", branch = "main" }` | yes |
| `{ "owner/repo", version = "*" }` / `"^1.0"` (semver range) | yes |
| `{ "owner/repo", tag = "v1.0" }` (explicit tag pin) | no |
| `{ "owner/repo", commit = "abc123" }` (explicit commit pin) | no |
| `{ "owner/repo", pin = true }` (excluded from updates) | no |

### Update behavior matrix

`info` = currently checked-out commit. `target` = the latest commit/tag that satisfies `minimum_release_age`.

| Scenario | `minimum_release_age_downgrade = false` (default) | `= true` |
|---|---|---|
| Fresh install, eligible target exists | check out `target` | check out `target` |
| Fresh install, every candidate is still in the cooldown window | install task errors with guidance to relax the constraint or retry later | same |
| `info == target` | no-op | no-op |
| `info` is an **ancestor** of `target` (info is older) | forward update to `target` | forward update to `target` |
| `info` is a **descendant** of `target` (info is newer than the eligible ceiling) | **keep `info`** (no downgrade); newer commits surfaced as `Pending` | roll back to `target` |
| Every candidate is too fresh (`target` is `nil`) | no-op; held-back ref surfaced as `Pending` | no-op |

`minimum_release_age_downgrade` honors per-plugin overrides identically to `minimum_release_age`. Fresh installs always honor `minimum_release_age` regardless of this flag.

### UI

Updates held back by `minimum_release_age` are surfaced in a new `Pending (minimum_release_age = ...)` section in the `:Lazy` UI, with per-line diagnostics showing the held commit or version plus an ETA:

```
Pending (minimum_release_age = "7d") (3)
  • fidget.nvim ...                       commit b33c466 (available in 4d)
  • lsp_signature.nvim ...                commit a1b2c3d (available in 2d)
  • md-render.nvim ...                    version 3.1.1 (available in 1d)
```

The ETA uses the same time source as the age filter (tag creatordate for tag targets, committer date for plain commit targets), so the displayed countdown matches when the candidate actually unlocks.

### Bundled refactor

This PR also includes a small refactor that derives lazy.nvim's auto-injected self-spec from the local clone's `origin` URL instead of hardcoding `folke/lazy.nvim`. This makes the new feature dogfoodable from a fork without manually patching the self-injection line, and is a general improvement for anyone running lazy.nvim from a non-official clone. Behavior is unchanged for upstream users -- their local origin already points to `folke/lazy.nvim`.

## Related Issue(s)

- https://github.com/folke/lazy.nvim/issues/2141

## Screenshots

The `:Lazy` UI shows fresh updates that have aged past `minimum_release_age` in the regular **Updates** section, while newer commits/tags still inside the cooldown window are surfaced in **Pending (minimum_release_age = "7d")** with a per-plugin ETA:

<img width="1203" height="472" alt="Screenshot 2026-05-23 at 4 15 30" src="https://github.com/user-attachments/assets/0d94e608-7198-4160-b88c-444c16be4667" />

