### PR TITLE
feat(git): add a hook that can enforce powerful commit selection policies

### DIFF
--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -361,7 +361,8 @@ SPEC VERSIONING                   *lazy.nvim-🔌-plugin-spec-spec-versioning*
 
   tag          string?              Tag of the repository
 
-  commit       string?              Commit of the repository
+  commit       string? or           Commit of the repository or a function
+               CommitHook           selecting the commit
 
   version      string? or false to  Version to use from the repository. Full
                override the default Semver ranges are supported
@@ -550,9 +551,77 @@ VERSIONING                             *lazy.nvim-🔌-plugin-spec-versioning*
 If you want to install a specific revision of a plugin, you can use `commit`,
 `tag`, `branch`, `version`.
 
+The `commit` and `defaults.commit` options can be a string or a `CommitHook`,
+which is a function that receives a `GitTarget` object describing the commit
+that would otherwise be selected (tag, version, or latest on the branch).
+The function returns one of:
+
+- a `string` to select a commit by its hash string
+- a `GitTarget` (e.g. the target it received) to use that target's commit
+
+The `GitTarget` object has the following methods:
+
+- `date()`: Unix timestamp of the commit
+- `age()`: age in days (number)
+- `short()`: 7-character hash
+- `message()`: commit subject
+- `author()`: author as `"Name <email>"`
+- `parent()`: returns a `GitTarget` for the parent commit, or nil at the root
+
+This is useful for implementing custom commit-selection logic. For example,
+to skip any commit that is less than 7 days old:
+
+>lua
+    require("lazy").setup({
+      defaults = {
+        commit = function(target)
+          while target and target:age() < 7 do
+            target = target:parent()
+          end
+          return target
+        end,
+      },
+    })
+<
+
+A more complex example skipping any commit that was followed up by another
+within 3 days:
+
+>lua
+    require("lazy").setup({
+      defaults = {
+        commit = function(target)
+          local last_age = 0
+          ---@type GitTarget?
+          local curr = target
+          while curr and curr:age() - last_age <= 3 do
+            last_age = curr:age()
+            curr = curr:parent()
+          end
+          return curr
+        end
+      },
+    })
+<
+
+And one more that skips commits authored by Github Copilot:
+
+>lua
+    require("lazy").setup({
+      defaults = {
+        commit = function(target)
+          ---@type GitTarget?
+          local curr = target
+          while curr and curr:author():match("copilot") do
+            curr = curr:parent()
+          end
+          return curr
+        end
+      },
+    })
+<
+
 The `version` property supports Semver <https://semver.org/> ranges.
-
-
 
 EXAMPLES ~
 
@@ -627,6 +696,10 @@ will be added to the plugin’s spec.
         -- default `cond` you can use to globally disable a lot of plugins
         -- when running inside vscode for example
         cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil
+        -- Set this to a function if you want to override the target commit. Receives a GitTarget
+        -- describing the commit that would otherwise be selected (tag, version, or latest on branch).
+        -- It should return a commit hash string or a GitTarget.
+        commit = nil, ---@type CommitHook?
       },
       -- leave nil when passing the spec as the first argument to setup()
       spec = nil, ---@type LazySpec

--- a/doc/lazy.nvim.txt
+++ b/doc/lazy.nvim.txt
@@ -553,8 +553,9 @@ If you want to install a specific revision of a plugin, you can use `commit`,
 
 The `commit` and `defaults.commit` options can be a string or a `CommitHook`,
 which is a function that receives a `GitTarget` object describing the commit
-that would otherwise be selected (tag, version, or latest on the branch).
-The function returns one of:
+that would otherwise be selected (tag, version, or latest on the branch), as
+well as the `LazyPlugin` the hook is being invoked for. The function returns
+one of:
 
 - a `string` to select a commit by its hash string
 - a `GitTarget` (e.g. the target it received) to use that target's commit
@@ -697,8 +698,9 @@ will be added to the plugin’s spec.
         -- when running inside vscode for example
         cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil
         -- Set this to a function if you want to override the target commit. Receives a GitTarget
-        -- describing the commit that would otherwise be selected (tag, version, or latest on branch).
-        -- It should return a commit hash string or a GitTarget.
+        -- describing the commit that would otherwise be selected (tag, version, or latest on branch),
+        -- and the LazyPlugin the hook is being invoked for. It should return a commit hash string
+        -- or a GitTarget.
         commit = nil, ---@type CommitHook?
       },
       -- leave nil when passing the spec as the first argument to setup()

--- a/lua/lazy/core/config.lua
+++ b/lua/lazy/core/config.lua
@@ -17,6 +17,10 @@ M.defaults = {
     -- default `cond` you can use to globally disable a lot of plugins
     -- when running inside vscode for example
     cond = nil, ---@type boolean|fun(self:LazyPlugin):boolean|nil
+    -- Set this to a function if you want to override the target commit. Receives a GitTarget
+    -- describing the commit that would otherwise be selected (tag, version, or latest on branch).
+    -- It should return a commit hash string or a GitTarget.
+    commit = nil, ---@type CommitHook?
   },
   -- leave nil when passing the spec as the first argument to setup()
   spec = nil, ---@type LazySpec

--- a/lua/lazy/manage/git.lua
+++ b/lua/lazy/manage/git.lua
@@ -249,7 +249,7 @@ function M.get_target(plugin)
   end
 
   local starting_target = M.target(plugin.dir, target_info)
-  local final_target = commit_hook(starting_target)
+  local final_target = commit_hook(starting_target, plugin)
 
   if type(final_target) == "string" then
     target_info.commit = final_target

--- a/lua/lazy/manage/git.lua
+++ b/lua/lazy/manage/git.lua
@@ -7,6 +7,90 @@ local M = {}
 
 ---@alias GitInfo {branch?:string, commit?:string, tag?:string, version?:Semver}
 
+---@class GitTarget
+local Target = {}
+Target.__index = Target
+
+---@param dir string
+---@param info GitInfo
+---@param commit string?
+---@return GitTarget
+local function target(dir, info, commit)
+  return setmetatable({
+    commit = commit or info.commit,
+    branch = info.branch,
+    dir = dir,
+    tag = info.tag,
+    version = info.version,
+  }, Target)
+end
+
+---@return number
+function Target:date()
+  local lines = Process.exec({
+    "git",
+    "show",
+    "-s",
+    "--format=%ct",
+    "--date=short",
+    self.commit,
+  }, { cwd = self.dir })
+  return tonumber(lines[1] or "0") or 0
+end
+
+---@return number
+function Target:age()
+  return math.floor((os.time() - self:date()) / 86400)
+end
+
+---@return string
+function Target:short()
+  return self.commit:sub(1, 7)
+end
+
+---@return string
+function Target:message()
+  local lines = Process.exec({
+    "git",
+    "show",
+    "-s",
+    "--format=%s",
+    self.commit,
+  }, { cwd = self.dir })
+  return lines[1] or ""
+end
+
+---@return string
+function Target:author()
+  local lines = Process.exec({
+    "git",
+    "show",
+    "-s",
+    "--format=%an <%ae>",
+    self.commit,
+  }, { cwd = self.dir })
+  return lines[1] or ""
+end
+
+---@return GitTarget?
+function Target:parent()
+  local lines = Process.exec({
+    "git",
+    "log",
+    "--pretty=format:%H",
+    "-n",
+    "2",
+    self.commit,
+  }, { cwd = self.dir })
+  local parent = lines[2]
+  if parent and parent ~= "" then
+    return target(self.dir, self, parent)
+  end
+  return nil
+end
+
+M.target = target
+
 ---@param repo string
 ---@param details? boolean Fetching details is slow! Don't loop over a plugin to fetch all details!
 ---@return GitInfo?
@@ -124,33 +208,55 @@ function M.get_target(plugin)
 
   local branch = assert(M.get_branch(plugin))
 
-  if plugin.commit then
+  if type(plugin.commit) == "string" then
     return {
       branch = branch,
       commit = plugin.commit,
     }
   end
+
+  ---@type GitInfo
+  local target_info
+
+  local version = (plugin.version == nil and plugin.branch == nil) and Config.options.defaults.version or plugin.version
   if plugin.tag then
-    return {
+    target_info = {
       branch = branch,
       tag = plugin.tag,
       commit = M.ref(plugin.dir, "tags/" .. plugin.tag),
     }
-  end
-
-  local version = (plugin.version == nil and plugin.branch == nil) and Config.options.defaults.version or plugin.version
-  if version then
+  elseif version then
     local last = Semver.last(M.get_versions(plugin.dir, version))
     if last then
-      return {
+      target_info = {
         branch = branch,
         version = last,
         tag = last.tag,
         commit = M.ref(plugin.dir, "tags/" .. last.tag),
       }
     end
+  else
+    target_info = { branch = branch, commit = M.get_commit(plugin.dir, branch, true) }
   end
-  return { branch = branch, commit = M.get_commit(plugin.dir, branch, true) }
+
+  local commit_hook = plugin.commit
+  if type(plugin.commit) ~= "function" and type(Config.options.defaults.commit) == "function" then
+    commit_hook = Config.options.defaults.commit
+  end
+
+  if type(commit_hook) ~= "function" then
+    return target_info
+  end
+
+  local starting_target = M.target(plugin.dir, target_info)
+  local final_target = commit_hook(starting_target)
+
+  if type(final_target) == "string" then
+    target_info.commit = final_target
+    return target_info
+  else
+    return final_target
+  end
 end
 
 function M.ref(repo, ...)

--- a/lua/lazy/manage/task/git.lua
+++ b/lua/lazy/manage/task/git.lua
@@ -359,8 +359,6 @@ M.checkout = {
       table.insert(args, lock.commit)
     elseif target.tag then
       table.insert(args, "tags/" .. target.tag)
-    elseif self.plugin.commit then
-      table.insert(args, self.plugin.commit)
     else
       table.insert(args, target.commit)
     end

--- a/lua/lazy/minit.lua
+++ b/lua/lazy/minit.lua
@@ -82,6 +82,18 @@ function M.setup(opts)
     M.busted.run()
   elseif is_minitest then
     M.minitest.run()
+    -- `mini.test` schedules its test queue via `vim.schedule` and returns
+    -- immediately. Under `nvim -l`, the main chunk would then end, causing
+    -- Neovim to begin its exit sequence (`getout(0)`), which permanently sets
+    -- `vim.v.exiting = 0` while the tests are still draining from the scheduler.
+    -- That makes `Util.exiting()` report `true`, which stops lazy's async
+    -- executor and hangs any synchronous `Process.exec()`/`:wait()` in a test.
+    -- Block here until `mini.test` is done so the script stays alive and
+    -- `mini.test` performs its own intentional exit (via `quit_on_finish`).
+    local MiniTest = require("mini.test")
+    vim.wait(10 * 60 * 1000, function()
+      return not MiniTest.is_executing()
+    end, 50)
   end
 end
 

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -40,10 +40,25 @@
 ---@field keys? table<string,LazyKeys>
 ---@field cmd? table<string,string>
 
+---@class GitTarget
+---@field commit string
+---@field branch string
+---@field dir string
+---@field tag? string
+---@field version? Semver
+---@field date fun(self: GitTarget): number
+---@field age fun(self: GitTarget): number
+---@field short fun(self: GitTarget): string
+---@field message fun(self: GitTarget): string
+---@field author fun(self: GitTarget): string
+---@field parent fun(self: GitTarget): GitTarget?
+
+---@alias CommitHook fun(target: GitTarget): (string | GitTarget)
+
 ---@class LazyPluginRef
 ---@field branch? string
 ---@field tag? string
----@field commit? string
+---@field commit? string | CommitHook
 ---@field version? string|boolean
 ---@field pin? boolean
 ---@field submodules? boolean Defaults to true

--- a/lua/lazy/types.lua
+++ b/lua/lazy/types.lua
@@ -53,7 +53,7 @@
 ---@field author fun(self: GitTarget): string
 ---@field parent fun(self: GitTarget): GitTarget?
 
----@alias CommitHook fun(target: GitTarget): (string | GitTarget)
+---@alias CommitHook fun(target: GitTarget, plugin: LazyPlugin): (string | GitTarget)
 
 ---@class LazyPluginRef
 ---@field branch? string

--- a/tests/manage/git_spec.lua
+++ b/tests/manage/git_spec.lua
@@ -1,0 +1,566 @@
+local Config = require("lazy.core.config")
+local Git = require("lazy.manage.git")
+local Process = require("lazy.manage.process")
+local Util = require("lazy.util")
+
+---@param dir string
+---@return string
+local function tmpdir(dir)
+  dir = dir or vim.fn.tempname()
+  vim.fn.mkdir(dir, "p")
+  return dir
+end
+
+---@param dir string
+local function git_init(dir)
+  Process.exec({ "git", "-C", dir, "init", "--quiet", "--initial-branch=main" })
+  Process.exec({ "git", "-C", dir, "config", "commit.gpgsign", "false" })
+end
+
+---@param repo string
+---@param message string
+---@param days_ago integer?
+---@param author string?
+---@return string commit hash
+local function git_commit(repo, message, days_ago, author)
+  days_ago = days_ago or 0
+  local date = os.date("!%Y-%m-%dT%H:%M:%SZ", os.time() - days_ago * 86400)
+  local name = author and vim.trim(author:match("^([^<]+)<")) or nil
+  local email = author and author:match("<([^>]+)>") or nil
+  Process.exec({
+    "git", "-C", repo, "commit", "--allow-empty", "--quiet", "-m", message,
+  }, {
+    env = {
+      GIT_AUTHOR_NAME = name or "Test",
+      GIT_AUTHOR_EMAIL = email or "test@local",
+      GIT_COMMITTER_NAME = name or "Test",
+      GIT_COMMITTER_EMAIL = email or "test@local",
+      GIT_AUTHOR_DATE = date,
+      GIT_COMMITTER_DATE = date,
+    },
+  })
+  local lines = Process.exec({ "git", "-C", repo, "rev-parse", "HEAD" })
+  return lines[1]
+end
+
+---@param dir string
+---@param name string
+---@return string commit hash
+local function git_tag(dir, name)
+  Process.exec({ "git", "-C", dir, "tag", name })
+  local lines = Process.exec({ "git", "-C", dir, "rev-parse", name })
+  return lines[1]
+end
+
+---@param repo string
+---@param branch? string
+---@return string
+local function head_of(repo, branch)
+  local lines = Process.exec({ "git", "-C", repo, "rev-parse", branch or "HEAD" })
+  return lines[1]
+end
+
+---@param plugin LazyPlugin
+---@return LazyPlugin
+local function with_dir(plugin)
+  return vim.tbl_extend("force", plugin, {
+    dir = plugin.dir,
+    url = plugin.dir,
+    name = plugin.name or "test",
+  })
+end
+
+describe("git get_target", function()
+  local repo
+
+  before_each(function()
+    repo = tmpdir()
+    git_init(repo)
+  end)
+
+  after_each(function()
+    if repo and vim.fn.isdirectory(repo) == 1 then
+      Util.walk(repo, function(path, _, type)
+        if type == "directory" then
+          vim.uv.fs_rmdir(path)
+        else
+          vim.uv.fs_unlink(path)
+        end
+      end)
+      vim.uv.fs_rmdir(repo)
+    end
+    Config.options.defaults.commit = nil
+  end)
+
+  it("returns HEAD commit for local plugin", function()
+    local head = git_commit(repo, "first")
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, _ = { is_local = true } })
+    local target = Git.get_target(plugin)
+    assert.same({ branch = "main", commit = head }, target)
+  end)
+
+  it("uses string plugin.commit when set", function()
+    git_commit(repo, "first")
+    local pinned = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, commit = pinned, _ = {} })
+    local target = Git.get_target(plugin)
+    assert.same({ branch = "main", commit = pinned }, target)
+  end)
+
+  it("calls function plugin.commit with natural target and uses string return", function()
+    local head = git_commit(repo, "first")
+    local returned = "1234567890abcdef1234567890abcdef12345678"
+    local received ---@type GitTarget?
+    ---@type LazyPlugin
+    local plugin = with_dir({
+      dir = repo,
+      commit = function(target)
+        received = target
+        return returned
+      end,
+      _ = {},
+    })
+    local target = Git.get_target(plugin)
+    assert.same(returned, target.commit)
+    assert.same(head, received.commit)
+    assert.same("main", received.branch)
+    assert.same(repo, received.dir)
+  end)
+
+  it("accepts GitTarget as the hook's return value", function()
+    local head = git_commit(repo, "first")
+    local picked = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    local received ---@type GitTarget?
+    ---@type LazyPlugin
+    local plugin = with_dir({
+      dir = repo,
+      commit = function(target)
+        received = target
+        return Git.target(repo, { commit = picked, branch = "main" })
+      end,
+      _ = {},
+    })
+    local target = Git.get_target(plugin)
+    assert.same(picked, target.commit)
+    assert.same(head, received.commit)
+  end)
+
+  it("passes through an invalid nil return value so failure can occur", function()
+    git_commit(repo, "first")
+    ---@type LazyPlugin
+    local plugin = with_dir({
+      dir = repo,
+      commit = function() return nil end,
+      _ = {},
+    })
+    local target = Git.get_target(plugin)
+    assert.is_nil(target)
+  end)
+
+  it("returns nil when function plugin.commit returns nil even with tag set", function()
+    git_commit(repo, "first")
+    git_tag(repo, "v1.0.0")
+    ---@type LazyPlugin
+    local plugin = with_dir({
+      dir = repo,
+      tag = "v1.0.0",
+      commit = function() return nil end,
+      _ = {},
+    })
+    local target = Git.get_target(plugin)
+    assert.is_nil(target)
+  end)
+
+  it("uses tag when plugin.tag is set and plugin.commit is nil", function()
+    git_commit(repo, "first")
+    local tag_commit = git_tag(repo, "v1.0.0")
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, tag = "v1.0.0", _ = {} })
+    local target = Git.get_target(plugin)
+    assert.same(tag_commit, target.commit)
+  end)
+
+  it("uses defaults.commit function when nothing more specific is set", function()
+    local head = git_commit(repo, "first")
+    local returned = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    local received ---@type GitTarget?
+    Config.options.defaults.commit = function(target)
+      received = target
+      return returned
+    end
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, _ = {} })
+    local target = Git.get_target(plugin)
+    assert.same(returned, target.commit)
+    assert.same(head, received.commit)
+  end)
+
+  it("returns nil when defaults.commit returns nil (no acceptable target)", function()
+    git_commit(repo, "first")
+    Config.options.defaults.commit = function() return nil end
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, _ = {} })
+    local target = Git.get_target(plugin)
+    assert.is_nil(target)
+  end)
+
+  it("calls defaults.commit hook with the natural target even when plugin.tag is set", function()
+    git_commit(repo, "first")
+    local tag_commit = git_tag(repo, "v1.0.0")
+    local returned = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    local received ---@type GitTarget?
+    Config.options.defaults.commit = function(target)
+      received = target
+      return returned
+    end
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, tag = "v1.0.0", _ = {} })
+    local target = Git.get_target(plugin)
+    assert.same(returned, target.commit)
+    assert.same(tag_commit, received.commit)
+    assert.same("v1.0.0", received.tag)
+  end)
+
+  it("prefers plugin.commit (string) over plugin.tag", function()
+    git_commit(repo, "first")
+    git_tag(repo, "v1.0.0")
+    local pinned = "feedfacefeedfacefeedfacefeedfacefeedface"
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, tag = "v1.0.0", commit = pinned, _ = {} })
+    local target = Git.get_target(plugin)
+    assert.same(pinned, target.commit)
+  end)
+
+  it("prefers plugin.commit (function) over plugin.tag and uses its return", function()
+    git_commit(repo, "first")
+    git_tag(repo, "v1.0.0")
+    local picked = "feedfacefeedfacefeedfacefeedfacefeedface"
+    ---@type LazyPlugin
+    local plugin = with_dir({
+      dir = repo,
+      tag = "v1.0.0",
+      commit = function() return picked end,
+      _ = {},
+    })
+    local target = Git.get_target(plugin)
+    assert.same(picked, target.commit)
+  end)
+
+  it("returns HEAD for local plugin even when commit function is set", function()
+    local head = git_commit(repo, "first")
+    local hook_called = false
+    Config.options.defaults.commit = function()
+      hook_called = true
+      return nil
+    end
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, _ = { is_local = true } })
+    local target = Git.get_target(plugin)
+    assert.same(head, target.commit)
+    assert.is_false(hook_called)
+  end)
+end)
+
+describe("git target", function()
+  local repo
+
+  before_each(function()
+    repo = tmpdir()
+    git_init(repo)
+  end)
+
+  after_each(function()
+    if repo and vim.fn.isdirectory(repo) == 1 then
+      Util.walk(repo, function(path, _, type)
+        if type == "directory" then
+          vim.uv.fs_rmdir(path)
+        else
+          vim.uv.fs_unlink(path)
+        end
+      end)
+      vim.uv.fs_rmdir(repo)
+    end
+  end)
+
+  it("exposes commit, branch, and dir", function()
+    git_commit(repo, "first")
+    local target = Git.target(repo, { commit = head_of(repo), branch = "main" })
+    assert.same(head_of(repo), target.commit)
+    assert.same("main", target.branch)
+    assert.same(repo, target.dir)
+  end)
+
+  it("short returns 7-char hash", function()
+    git_commit(repo, "first")
+    local target = Git.target(repo, { commit = head_of(repo), branch = "main" })
+    assert.same(7, #target:short())
+  end)
+
+  it("message returns commit subject", function()
+    git_commit(repo, "the message")
+    local target = Git.target(repo, { commit = head_of(repo), branch = "main" })
+    assert.same("the message", target:message())
+  end)
+
+  it("author returns name and email", function()
+    git_commit(repo, "the message")
+    local target = Git.target(repo, { commit = head_of(repo), branch = "main" })
+    local author = target:author()
+    assert(author:find("Test", 1, true), author)
+    assert(author:find("test@local", 1, true), author)
+  end)
+
+  it("date returns a positive Unix timestamp", function()
+    git_commit(repo, "first")
+    local target = Git.target(repo, { commit = head_of(repo), branch = "main" })
+    local ts = target:date()
+    assert(ts > 0)
+    assert(type(ts) == "number")
+  end)
+
+  it("age returns a number of days", function()
+    git_commit(repo, "first")
+    local target = Git.target(repo, { commit = head_of(repo), branch = "main" })
+    local age = target:age()
+    assert(type(age) == "number")
+    assert(age >= 0)
+  end)
+
+  it("parent walks back through commits on the same branch", function()
+    local first = git_commit(repo, "first")
+    local second = git_commit(repo, "second")
+    local target = Git.target(repo, { commit = second, branch = "main" })
+    assert.same(second, target.commit)
+    local parent = target:parent()
+    assert(parent ~= nil)
+    assert.same(first, parent.commit)
+    assert.same("main", parent.branch)
+    assert.same(repo, parent.dir)
+  end)
+
+  it("parent returns nil at the initial commit", function()
+    local first = git_commit(repo, "first")
+    local target = Git.target(repo, { commit = first, branch = "main" })
+    assert.is_nil(target:parent())
+  end)
+end)
+
+  ---@param repo string
+  ---@param hook CommitHook
+  local function run_hook(repo, hook)
+    ---@type LazyPlugin
+    local plugin = with_dir({ dir = repo, commit = hook, _ = {} })
+    return Git.get_target(plugin)
+  end
+
+describe("git commit hook: restrict to human commits", function()
+  local repo
+
+  local human_author = "John Doe <john.doe@noreply.github.com>"
+  local robot_author = "GitHub Copilot <copilot@github.com>"
+
+  ---@param target GitTarget
+  local function human_commit(target)
+    ---@type GitTarget?
+    local curr = target
+    while curr and curr:author():match("copilot") do
+      curr = curr:parent()
+    end
+    return curr
+  end
+
+  before_each(function()
+    repo = tmpdir()
+    git_init(repo)
+  end)
+
+  after_each(function()
+    if repo and vim.fn.isdirectory(repo) == 1 then
+      Util.walk(repo, function(path, _, type)
+        if type == "directory" then
+          vim.uv.fs_rmdir(path)
+        else
+          vim.uv.fs_unlink(path)
+        end
+      end)
+      vim.uv.fs_rmdir(repo)
+    end
+    Config.options.defaults.commit = nil
+  end)
+
+  it("returns HEAD when HEAD is not authored by the robot", function()
+    local head = git_commit(repo, "fresh")
+    local target = run_hook(repo, human_commit)
+    assert.same(head, target.commit)
+  end)
+
+  it("returns HEAD when HEAD itself is not authored by the robot", function()
+    local head = git_commit(repo, "old", 5, human_author)
+    local target = run_hook(repo, human_commit)
+    assert.same(head, target.commit)
+  end)
+
+  it("returns nil when all commits are authored by a robot", function()
+    git_commit(repo, "c1", 5, robot_author)
+    git_commit(repo, "c2", 3, robot_author)
+    git_commit(repo, "c3", 1, robot_author)
+    assert.is_nil(run_hook(repo, human_commit))
+  end)
+
+  it("returns the newest commit that is not authored by the robot", function()
+    local desired_commit = git_commit(repo, "c1", 5, human_author)
+    git_commit(repo, "c2", 1, robot_author)
+    git_commit(repo, "c3", 0, robot_author)
+    local target = run_hook(repo, human_commit)
+    assert.same(desired_commit, target.commit)
+  end)
+end)
+
+describe("git commit hook: restrict to cool commits", function()
+  local repo
+
+  ---@param target GitTarget
+  local function cool_commit(target)
+    ---@type GitTarget?
+    local curr = target
+    while curr and curr:age() < 7 do
+      curr = curr:parent()
+    end
+    return curr
+  end
+
+  before_each(function()
+    repo = tmpdir()
+    git_init(repo)
+  end)
+
+  after_each(function()
+    if repo and vim.fn.isdirectory(repo) == 1 then
+      Util.walk(repo, function(path, _, type)
+        if type == "directory" then
+          vim.uv.fs_rmdir(path)
+        else
+          vim.uv.fs_unlink(path)
+        end
+      end)
+      vim.uv.fs_rmdir(repo)
+    end
+    Config.options.defaults.commit = nil
+  end)
+
+  it("returns nil for a single fresh commit (nothing has cooled off)", function()
+    git_commit(repo, "fresh")
+    assert.is_nil(run_hook(repo, cool_commit))
+  end)
+
+  it("returns HEAD when HEAD itself is more than 7 days old", function()
+    local head = git_commit(repo, "old", 8)
+    local target = run_hook(repo, cool_commit)
+    assert.same(head, target.commit)
+  end)
+
+  it("returns nil when recent commits are rapid-fire (no commit older than 7 days)", function()
+    git_commit(repo, "c1", 0)
+    git_commit(repo, "c2", 0)
+    git_commit(repo, "c3", 0)
+    assert.is_nil(run_hook(repo, cool_commit))
+  end)
+
+  it("returns the newest commit that is older than 7 days", function()
+    local oldest = git_commit(repo, "c1", 8)
+    git_commit(repo, "c2", 1)
+    git_commit(repo, "c3", 0)
+    local target = run_hook(repo, cool_commit)
+    assert.same(oldest, target.commit)
+  end)
+
+  it("returns nil when no commit is older than 7 days, even with many commits", function()
+    git_commit(repo, "c1", 4)
+    git_commit(repo, "c2", 3)
+    git_commit(repo, "c3", 2)
+    git_commit(repo, "c4", 1)
+    git_commit(repo, "c5", 0)
+    assert.is_nil(run_hook(repo, cool_commit))
+  end)
+end)
+
+describe("git commit hook: restrict to stable commits", function()
+  local repo
+
+  ---@param target GitTarget
+  local function stable_commit(target)
+    local last_age = 0
+    ---@type GitTarget?
+    local curr = target
+    while curr and curr:age() - last_age <= 3 do
+      last_age = curr:age()
+      curr = curr:parent()
+    end
+    return curr
+  end
+
+  before_each(function()
+    repo = tmpdir()
+    git_init(repo)
+  end)
+
+  after_each(function()
+    if repo and vim.fn.isdirectory(repo) == 1 then
+      Util.walk(repo, function(path, _, type)
+        if type == "directory" then
+          vim.uv.fs_rmdir(path)
+        else
+          vim.uv.fs_unlink(path)
+        end
+      end)
+      vim.uv.fs_rmdir(repo)
+    end
+    Config.options.defaults.commit = nil
+  end)
+
+  it("returns nil for a single fresh commit (nothing has cooled off)", function()
+    git_commit(repo, "fresh")
+    assert.is_nil(run_hook(repo, stable_commit))
+  end)
+
+  it("returns HEAD when HEAD itself is more than 3 days old", function()
+    local head = git_commit(repo, "old", 5)
+    local target = run_hook(repo, stable_commit)
+    assert.same(head, target.commit)
+  end)
+
+  it("returns nil when recent commits are rapid-fire (no gap exceeds 3 days)", function()
+    git_commit(repo, "c1", 0)
+    git_commit(repo, "c2", 0)
+    git_commit(repo, "c3", 0)
+    assert.is_nil(run_hook(repo, stable_commit))
+  end)
+
+  it("returns the newest commit whose gap to its successor exceeds 3 days", function()
+    local oldest = git_commit(repo, "c1", 5)
+    git_commit(repo, "c2", 1)
+    git_commit(repo, "c3", 0)
+    local target = run_hook(repo, stable_commit)
+    assert.same(oldest, target.commit)
+  end)
+
+  it("picks the newest cooled-off commit, not the oldest one", function()
+    git_commit(repo, "c1", 20)
+    local middle = git_commit(repo, "c2", 5)
+    git_commit(repo, "c3", 1)
+    git_commit(repo, "c4", 0)
+    local target = run_hook(repo, stable_commit)
+    assert.same(middle, target.commit)
+  end)
+
+  it("returns nil when every gap is under 3 days, even with many commits", function()
+    git_commit(repo, "c1", 4)
+    git_commit(repo, "c2", 3)
+    git_commit(repo, "c3", 2)
+    git_commit(repo, "c4", 1)
+    git_commit(repo, "c5", 0)
+    assert.is_nil(run_hook(repo, stable_commit))
+  end)
+end)

--- a/tests/manage/git_spec.lua
+++ b/tests/manage/git_spec.lua
@@ -116,7 +116,7 @@ describe("git get_target", function()
     ---@type LazyPlugin
     local plugin = with_dir({
       dir = repo,
-      commit = function(target)
+      commit = function(target, _)
         received = target
         return returned
       end,
@@ -136,7 +136,7 @@ describe("git get_target", function()
     ---@type LazyPlugin
     local plugin = with_dir({
       dir = repo,
-      commit = function(target)
+      commit = function(target, _)
         received = target
         return Git.target(repo, { commit = picked, branch = "main" })
       end,
@@ -186,7 +186,7 @@ describe("git get_target", function()
     local head = git_commit(repo, "first")
     local returned = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
     local received ---@type GitTarget?
-    Config.options.defaults.commit = function(target)
+    Config.options.defaults.commit = function(target, _)
       received = target
       return returned
     end
@@ -211,7 +211,7 @@ describe("git get_target", function()
     local tag_commit = git_tag(repo, "v1.0.0")
     local returned = "abcdefabcdefabcdefabcdefabcdefabcdefabcd"
     local received ---@type GitTarget?
-    Config.options.defaults.commit = function(target)
+    Config.options.defaults.commit = function(target, _)
       received = target
       return returned
     end
@@ -362,7 +362,8 @@ describe("git commit hook: restrict to human commits", function()
   local robot_author = "GitHub Copilot <copilot@github.com>"
 
   ---@param target GitTarget
-  local function human_commit(target)
+  ---@param plugin LazyPlugin
+  local function human_commit(target, _)
     ---@type GitTarget?
     local curr = target
     while curr and curr:author():match("copilot") do
@@ -422,7 +423,8 @@ describe("git commit hook: restrict to cool commits", function()
   local repo
 
   ---@param target GitTarget
-  local function cool_commit(target)
+  ---@param plugin LazyPlugin
+  local function cool_commit(target, _)
     ---@type GitTarget?
     local curr = target
     while curr and curr:age() < 7 do
@@ -490,7 +492,8 @@ describe("git commit hook: restrict to stable commits", function()
   local repo
 
   ---@param target GitTarget
-  local function stable_commit(target)
+  ---@param plugin LazyPlugin
+  local function stable_commit(target, _)
     local last_age = 0
     ---@type GitTarget?
     local curr = target


### PR DESCRIPTION
## Description

Resolves #2141 by introducing a `CommitHook` — a flexible extension point that lets users implement their own commit-selection logic (such as a minimum age requirement) without forcing a built-in policy on everyone.

The original issue asked for a built-in minimum commit age feature to reduce churn from broken commits. There was resistance to shipping such a feature directly: aging is one of many possible rules users might want (such as skipping CI bot commits, commits with a rapid followup, fresh commits, etc.), and baking a specific policy into core would either impose one user's preferences on everyone or require a pile of configuration that overlaps with this generic mechanism.

This change provides the generic mechanism instead and lets users decide what to enforce.

What it does:

- Adds a `commit` field to `defaults` and allows it or the per-spec `commit` to contain a `CommitHook` function.
- The hook receives a `GitTarget` describing the commit that would otherwise be selected (resolved tag, version, or latest on the branch) and returns either:
  - a commit hash string, or
  - a `GitTarget` (e.g. the target itself, or one of its parents via `target:parent()`).
- `GitTarget` exposes methods useful for writing rules: `:date()`, `:age()`, `:short()`, `:message()`, `:author()`, `:parent()`.
- A per-spec commit function wins over the global default when both are set.

Examples:

Skip commits newer than 7 days (the original use case from the issue):

```lua
require("lazy").setup({
  defaults = {
    commit = function(target)
      ---@type GitTarget?
      local curr = target
      while curr and curr:age() < 7 do
        curr = curr:parent()
      end
      return curr
    end,
  },
})
```

Skip commits followed up within 3 days:

```lua
require("lazy").setup({
  defaults = {
    commit = function(target)
      local last_age = 0
      ---@type GitTarget?
      local curr = target
      while curr and curr:age() - last_age <= 3 do
        last_age = curr:age()
        curr = curr:parent()
      end
      return curr
    end
  },
})
```

Skip commits authored by Github Copilot:

```lua
require("lazy").setup({
  defaults = {
    commit = function(target)
      ---@type GitTarget?
      local curr = target
      while curr and curr:author():match("copilot") do
        curr = curr:parent()
      end
      return curr
    end
  },
})
```

Notes:

- The commit field remains backward compatible when set to a string.
- git.lua was refactored to share the target-building path between the hook and the unchanged string-commit case; the special-cased branch in manage/task/git.lua was removed in favor of resolving through get_target.
- Tests added in tests/manage/git_spec.lua cover both the hook behavior and the unchanged paths. The tests are significantly slower than the other tests, which may explain why there were no tests covering git behavior before. They are standalone and easily removed.

As an aside, this pull request includes a commit that modifies the test framework. Under `nvim -l`, mini.test's scheduler-based queue was being torn down by Neovim's exit sequence before tests drained, which set `vim.v.exiting` mid-flight and caused lazy's async executor to hang. The test entrypoint now blocks on `MiniTest.is_executing()` so mini.test's own `quit_on_finish` runs cleanly. If desired, that commit can be spun off or removed entirely. I just needed it for the tests to work, but there probably is a better way to solve that particular problem.

## Related Issue(s)

Fixes #2141

## Screenshots

N/A
