### PR TITLE
fix(pkg): stop reloading specs with unbounded recursion when the pkg cache cannot be loaded

### DIFF
--- a/lua/lazy/core/plugin.lua
+++ b/lua/lazy/core/plugin.lua
@@ -319,7 +319,8 @@ function M.find_local_spec()
   end
 end
 
-function M.load()
+---@param retry? boolean true when re-entering after `Pkg.update()`
+function M.load(retry)
   M.loading = true
   -- load specs
   Util.track("spec")
@@ -377,9 +378,9 @@ function M.load()
   M.update_state()
   Util.track()
 
-  if Config.options.pkg.enabled and Pkg.dirty then
+  if Config.options.pkg.enabled and Pkg.dirty and not retry then
     Pkg.update()
-    return M.load()
+    return M.load(true)
   end
 
   M.loading = false

--- a/tests/core/plugin_spec.lua
+++ b/tests/core/plugin_spec.lua
@@ -524,3 +524,40 @@ describe("plugin spec", function()
     end
   end)
 end)
+
+describe("pkg cache reload", function()
+  local Pkg = require("lazy.pkg")
+  local orig = { loadfile = _G.loadfile, update = Pkg.update, plugins = Config.plugins, spec = Config.spec }
+  local pkg_opts = { enabled = Config.options.pkg.enabled, cache = Config.options.pkg.cache }
+
+  after_each(function()
+    _G.loadfile, Pkg.update = orig.loadfile, orig.update
+    Config.plugins, Config.spec = orig.plugins, orig.spec
+    Config.options.pkg.enabled, Config.options.pkg.cache = pkg_opts.enabled, pkg_opts.cache
+    rawset(Pkg, "cache", nil)
+    Pkg.dirty = false
+  end)
+
+  it("regenerates the cache at most once per load", function()
+    local cache = vim.fn.tempname() .. "/pkg-cache.lua"
+    Config.options.pkg.enabled, Config.options.pkg.cache = true, cache
+    rawset(Pkg, "cache", nil)
+    Pkg.dirty = false
+    _G.loadfile = function(path, ...)
+      if path == cache then
+        error("EACCES: simulated")
+      end
+      return orig.loadfile(path, ...)
+    end
+    local updates = 0
+    Pkg.update = function(...)
+      updates = updates + 1
+      if updates > 1 then
+        error("Pkg.update called more than once")
+      end
+      return orig.update(...)
+    end
+    Plugin.load()
+    assert.equals(1, updates)
+  end)
+end)


### PR DESCRIPTION
## Description
I've encountered a memory leak.
`M.load()` in `lua/lazy/core/plugin.lua` ends with:

```lua
  if Config.options.pkg.enabled and Pkg.dirty then
    Pkg.update()
    return M.load()
  end
```

`Pkg.update()` writes `pkg-cache.lua` and clears `Pkg.cache`. The next `M.load()` re-parses all specs and `_load()` calls `loadfile(Config.options.pkg.cache)` inside `Util.try`. If that `loadfile` raises, `_load()` marks the cache dirty again, and `M.load()` calls `Pkg.update()` again and tail-calls itself.

Because the recursion is a proper tail call, the stack stays flat and nothing yields to the event loop. Memory grew ~1 MB/s. Two processes reached 8.8GB each after 5hrs on my machine. Repro on NVIM 0.12.5 with lazy.nvim v11.17.5 and current main (`306a0552`), with an empty spec.

The fix gives `M.load()` a `retry` flag so the cache is regenerated at most once per load. If loading it fails a second time, lazy continues with an empty pkg cache and the queued error notification can surface.

Reproduction without any sandbox:

```sh
tmp=$(mktemp -d)
mkdir -p $tmp/config/nvim $tmp/data/nvim/lazy $tmp/cache
git clone --filter=blob:none --branch=stable https://github.com/folke/lazy.nvim.git $tmp/data/nvim/lazy/lazy.nvim
cat > $tmp/config/nvim/init.lua <<'LUA'
vim.opt.rtp:prepend(vim.fn.stdpath("data") .. "/lazy/lazy.nvim")
require("lazy").setup({ spec = {}, install = { missing = false }, rocks = { enabled = false } })
LUA
export XDG_CONFIG_HOME=$tmp/config XDG_DATA_HOME=$tmp/data XDG_CACHE_HOME=$tmp/cache
XDG_STATE_HOME=$tmp/state1 nvim --headless +qa   # warm run, exits
chmod 555 $tmp/cache/nvim/luac
XDG_STATE_HOME=$tmp/state2 nvim --headless +qa   # never exits, RSS grows forever
```

## Related Issue(s)

No issue filed yet; this PR carries the full report and reproduction.


Related: #2109 adds another place that sets `Pkg.dirty = true` inside `Meta:fix_pkgs()`; the guard here bounds that re-entry path as well, so the two compose.
## Screenshots

Not applicable.

Fable assisted with this PR.


